### PR TITLE
Add listener module to gmail connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 #Config file
 Config.toml
 # Modules
-/modules
+/modules/googleapis_gmail
 
 # BlueJ files
 *.ctxt

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "googleapis_gmail"
-version = "0.99.4"
+version = "0.99.5"
 authors = ["Ballerina"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-googleapis.gmail"
 keywords = ["gmail","email"]

--- a/Package.md
+++ b/Package.md
@@ -86,3 +86,206 @@ public function main(string... args) {
     }
 }
 ```
+# Listener Module
+
+Connects to Gmail Listener using Ballerina.
+
+# Module Overview
+
+The Gmail Listener Ballerina Connector provides the capability to listen the push notification for changes to Gmail mailboxes. The Gmail Listener Ballerina Connector supports to listen the changes of Gmail mailboxes such as receiving new message, receiving new thread, adding new label to a message, adding star to a message, removing label to a message, removing star to a message and receiving a new attachment with following trigger methods: `onMailboxChanges`, `onNewEmail`, `onNewThread`, `onNewLabeledEmail`, `onNewStaredEmail`, `onLabelRemovedEmail`,`onStarRemovedEmail`, `onNewAttachment`.
+
+
+# Prerequisites:
+
+* Java 11 Installed
+Java Development Kit (JDK) with version 11 is required.
+
+* Download the Ballerina [distribution](https://ballerinalang.org/downloads/)
+Ballerina Swan Lake Alpha 2 is required.
+
+* Instantiate the connector by giving authentication details in the HTTP client config. The HTTP client config has built-in support for BasicAuth and OAuth 2.0. Gmail uses OAuth 2.0 to authenticate and authorize requests. The Gmail connector can be minimally instantiated in the HTTP client config using the client ID, client secret, and refresh token.
+    * Client ID
+    * Client Secret
+    * Refresh Token
+    * Refresh URL
+
+## Obtaining Tokens
+
+1. Visit [Google API Console](https://console.developers.google.com), click **Create Project**, and follow the wizard to create a new project.
+2. Go to **Library** from the left side menu. In the search bar enter required API/Service name(Eg: Gmail). Then select required service and click **Enable** button.
+3. Go to **Credentials -> OAuth consent screen**, enter a product name to be shown to users, and click **Save**.
+4. On the **Credentials** tab, click **Create credentials** and select **OAuth client ID**. 
+5. Select an application type, enter a name for the application, and specify a redirect URI (enter https://developers.google.com/oauthplayground if you want to use 
+[OAuth 2.0 playground](https://developers.google.com/oauthplayground) to receive the authorization code and obtain the refresh token). 
+6. Click **Create**. Your client ID and client secret appear. 
+7. In a separate browser window or tab, visit [OAuth 2.0 playground](https://developers.google.com/oauthplayground), select the required Gmail scopes, and then click **Authorize APIs**.
+
+8. When you receive your authorization code, click **Exchange authorization code for tokens** to obtain the refresh token.
+
+## Create push topic and subscription
+To use Gmail Listener connector, a topic and a subscription should be configured.
+
+1. Enable Cloud Pub/Sub API for your project which is created in [Google API Console](https://console.developers.google.com).
+2. Go to [Google Cloud Pub/Sub API management console](https://console.cloud.google.com/cloudpubsub/topic/list)  and create a topic([You can follow the instructions here](https://cloud.google.com/pubsub/docs/quickstart-console) and a subscription to that topic. The subscription should be a pull subscription in this case ([Find mode details here](https://cloud.google.com/pubsub/docs/subscriber))).
+3. For the push subscription , an endpoint URL should be given to push the notification. This URL is the URL where the gmail listener service runs. This should be in `https`  format. (If the service runs in localhost, then ngrok can be used to get an `https` URL).
+4. Grant publish right on your topic. [To do this, see the instructions here](https://developers.google.com/gmail/api/guides/push#grant_publish_rights_on_your_topic).
+
+5. Once you have done the above steps, get your topic name (It will be in the format of `projects/<YOUR_PROJECT_NAME>topics/<YOUR_TOPIC_NAME>`) from your console and give it to the `Config.toml` file as `topicName`.
+
+
+## Add project configurations file
+Add the project configuration file by creating a `Config.toml` file under the root path of the project structure.
+This file should have following configurations. Add the token obtained in the previous step to the `Config.toml` file.
+
+```
+[ballerinax.googleapis_gmail]
+refreshToken = "enter your refresh token here"
+clientId = "enter your client id here"
+clientSecret = "enter your client secret here"
+port = "enter the port where your listener runs"
+topicName = "enter your push topic name"
+
+```
+
+# Compatibility
+
+| Ballerina Language Versions  | Gmail API Version |
+|:----------------------------:|:-----------------:|
+|  Swan Lake Alpha 2           |   v1              |
+
+# Quickstart(s):
+
+## Working with Gmail Listener
+
+### Step 1: Import Gmail and Gmail Listener Ballerina Library
+First, import the ballerinax/googleapis_gmail and ballerinax/googleapis_gmail.'listener module into the Ballerina project.
+```ballerina
+    import ballerinax/googleapis_gmail as gmail;
+    import ballerinax/googleapis_gmail.'listener as gmailListener;
+```
+
+### Step 2: Initialize the Gmail Client and Gmail Listener
+In order for you to use the Gmail Listener Endpoint, first you need to create a Gmail Client endpoint and a Gmail Listener endpoint.
+```ballerina
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+```
+Then the endpoint triggers can be invoked as `var response = gmailEventListener->triggerName(arguments)`.
+
+
+# Samples
+
+### On New Email
+
+Triggers when a new e-mail appears in the mail inbox.
+
+```ballerina
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewEmail(response);
+            if(triggerResponse is gmail:Message[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var msg in triggerResponse {
+                        log:print("Message ID: "+msg.id + " Thread ID: "+ msg.threadId+ " Snippet: "+msg.snippet);
+                    }
+                }
+            }
+        }
+    }     
+}
+```
+
+### On New Labeled Email
+
+Triggers when you label an email.
+
+```ballerina
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewLabeledEmail(response);
+            if(triggerResponse is gmailListener:ChangedLabel[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var changedLabel in triggerResponse {
+                        log:print("Message ID: "+ changedLabel.message.id + " Changed Label ID: "
+                            +changedLabel.changedLabelId[0]);
+                    }
+                }
+            }
+        }
+    }     
+}
+```
+More samples are available at "https://github.com/ballerina-platform/module-ballerinax-googleapis.gmail/tree/master/samples/listener".

--- a/constants.bal
+++ b/constants.bal
@@ -43,6 +43,10 @@ const string HISTORY_RESOURCE = "/history";
 const string DRAFT_RESOURCE = "/drafts";
 # Holds the value for send draft resource.
 const string DRAFT_SEND_RESOURCE = "/drafts/send";
+# Holds the value for watch mailbox resource path.
+public const string WATCH = "/watch";
+# Holds the value for stop watch mailbox resource path.
+public const string STOP = "/stop";
 
 # Holds the value for empty string.
 const string EMPTY_STRING = "";

--- a/data_mappings.bal
+++ b/data_mappings.bal
@@ -460,64 +460,75 @@ function convertJSONToHistoryType(json sourceJsonHistory) returns @tainted Histo
         }
         // messagesAdded
         if (elementExists(srcJsonHisMap, "messagesAdded")) {
-            targetHistory.messagesAdded = 
-                convertJSONToMsgTypeList(<json[]>srcJsonHisMap["messagesAdded"], targetHistory.messages);
+            var addedMessages = srcJsonHisMap["messagesAdded"];
+            if(addedMessages is json[]) {
+                foreach var addedMessage in addedMessages {
+                    var historyChange = addedMessage.cloneWithType(HistoryChange);
+                    if(historyChange is HistoryChange) {
+                        array:push(targetHistory.messagesAdded,historyChange);
+                    } else {
+                        log:printError("Error occured while converting to HistoryChange type", err = historyChange);
+                    }
+                }                
+            } else {
+                log:printError("History change related 'messagesAdded' is not in the format of json[]");
+            }
         } else {
             targetHistory.messagesAdded = [];
         }
         // messagesDeleted
         if (elementExists(srcJsonHisMap, "messagesDeleted")) {
-            targetHistory.messagesDeleted = 
-                convertJSONToMsgTypeList(<json[]>srcJsonHisMap["messagesDeleted"], targetHistory.messages);
+            var deletedMessages = srcJsonHisMap["messagesDeleted"];
+            if(deletedMessages is json[]) {
+                foreach var deletedMessage in deletedMessages {
+                    var historyChange = deletedMessage.cloneWithType(HistoryChange);
+                    if(historyChange is HistoryChange) {
+                        array:push(targetHistory.messagesDeleted,historyChange);
+                    } else {
+                        log:printError("Error occured while converting to HistoryChange type", err = historyChange);
+                    }
+                }                
+            } else {
+                log:printError("History change related 'messagesDeleted' is not in the format of json[]");
+            }
         } else {
             targetHistory.messagesDeleted = [];
         }
         // labelsAdded
         if (elementExists(srcJsonHisMap, "labelsAdded")) {
-            json|error lbls = sourceJsonHistory.labelsAdded;
-            if (lbls is json) {
-                foreach json recordData in <json[]>lbls {
-                    json|error message = recordData.message;
-                    if(message is json) {
-                        array:push(targetHistory.labelsAdded, { "message": convertJSONToMessageType(message) });
+            var addedLabels = srcJsonHisMap["labelsAdded"];
+            if(addedLabels is json[]) {
+                foreach var addedLabel in addedLabels {
+                    var historyChange = addedLabel.cloneWithType(HistoryChange);
+                    if(historyChange is HistoryChange) {
+                        array:push(targetHistory.labelsAdded,historyChange);
                     } else {
-                        log:printError("Error occurred while getting recordData.", err = message);
+                        log:printError("Error occured while converting to HistoryChange type", err = historyChange);
                     }
-                    json|error labelIds = recordData.labelIds;
-                    if (labelIds is json) {
-                        array:push(targetHistory.labelsRemoved, 
-                            { labelIds: convertJSONArrayToStringArray(<json[]>labelIds) });
-                    } else {
-                        log:printError("Error occurred while getting label is from record data.", err = labelIds);
-                    }
-                }
+                }                
             } else {
-                log:printError("Error occurred while getting history", err = lbls);
+                log:printError("History change related 'labelsAdded' is not in the format of json[]");
             }
-
+        } else {
+            targetHistory.labelsAdded = [];
         }
         // labelsRemoved
         if (elementExists(srcJsonHisMap, "labelsRemoved")) {
-            json|error lblsRemoved = sourceJsonHistory.labelsRemoved;
-            if (lblsRemoved is json) {
-                foreach json recordData in <json[]>lblsRemoved {
-                    json|error message = recordData.message;
-                    if(message is json) {
-                        array:push(targetHistory.labelsRemoved, { "message": convertJSONToMessageType(message) });
+            var removedLabels = srcJsonHisMap["labelsRemoved"];
+            if(removedLabels is json[]) {
+                foreach var removedLabel in removedLabels {
+                    var historyChange = removedLabel.cloneWithType(HistoryChange);
+                    if(historyChange is HistoryChange) {
+                        array:push(targetHistory.labelsRemoved,historyChange);
                     } else {
-                        log:printError("Error occurred while getting recordData.", err = message);
+                        log:printError("Error occured while converting to HistoryChange type", err = historyChange);
                     }
-                    json|error labelIds = recordData.labelIds;
-                    if (labelIds is json) {
-                        array:push(targetHistory.labelsRemoved, 
-                            { labelIds: convertJSONArrayToStringArray(<json[]>labelIds) });
-                    } else {
-                        log:printError("Error occurred while getting label is from record data.", err = labelIds);
-                    }
-                }
+                }                
             } else {
-                log:printError("Error occurred while getting labels", err = lblsRemoved);
+                log:printError("History change related 'labelsRemoved' is not in the format of json[]");
             }
+        } else {
+            targetHistory.labelsRemoved = [];
         }
     }
     return targetHistory;

--- a/data_mappings.bal
+++ b/data_mappings.bal
@@ -131,7 +131,7 @@ isolated function convertJSONToMsgBodyAttachment(json sourceMessageBodyJsonObjec
     return {
         fileId: let var fileId = sourceMessageBodyJsonObject.attachmentId in fileId is string ? fileId : EMPTY_STRING,
         body: let var body = sourceMessageBodyJsonObject.data in body is string ? body : EMPTY_STRING,
-        size: let var size = sourceMessageBodyJsonObject.body.size in size is int ? size.toString() : EMPTY_STRING
+        size: let var size = sourceMessageBodyJsonObject.size in size is int ? size.toString() : EMPTY_STRING
     };
 }
 
@@ -463,11 +463,11 @@ function convertJSONToHistoryType(json sourceJsonHistory) returns @tainted Histo
             var addedMessages = srcJsonHisMap["messagesAdded"];
             if(addedMessages is json[]) {
                 foreach var addedMessage in addedMessages {
-                    var historyChange = addedMessage.cloneWithType(HistoryChange);
-                    if(historyChange is HistoryChange) {
-                        array:push(targetHistory.messagesAdded,historyChange);
+                    var historyEvent = addedMessage.cloneWithType(HistoryEvent);
+                    if(historyEvent is HistoryEvent) {
+                        array:push(targetHistory.messagesAdded,historyEvent);
                     } else {
-                        log:printError("Error occured while converting to HistoryChange type", err = historyChange);
+                        log:printError("Error occured while converting to HistoryEvent type", err = historyEvent);
                     }
                 }                
             } else {
@@ -481,11 +481,11 @@ function convertJSONToHistoryType(json sourceJsonHistory) returns @tainted Histo
             var deletedMessages = srcJsonHisMap["messagesDeleted"];
             if(deletedMessages is json[]) {
                 foreach var deletedMessage in deletedMessages {
-                    var historyChange = deletedMessage.cloneWithType(HistoryChange);
-                    if(historyChange is HistoryChange) {
-                        array:push(targetHistory.messagesDeleted,historyChange);
+                    var historyEvent = deletedMessage.cloneWithType(HistoryEvent);
+                    if(historyEvent is HistoryEvent) {
+                        array:push(targetHistory.messagesDeleted,historyEvent);
                     } else {
-                        log:printError("Error occured while converting to HistoryChange type", err = historyChange);
+                        log:printError("Error occured while converting to HistoryEvent type", err = historyEvent);
                     }
                 }                
             } else {
@@ -499,11 +499,11 @@ function convertJSONToHistoryType(json sourceJsonHistory) returns @tainted Histo
             var addedLabels = srcJsonHisMap["labelsAdded"];
             if(addedLabels is json[]) {
                 foreach var addedLabel in addedLabels {
-                    var historyChange = addedLabel.cloneWithType(HistoryChange);
-                    if(historyChange is HistoryChange) {
-                        array:push(targetHistory.labelsAdded,historyChange);
+                    var historyEvent = addedLabel.cloneWithType(HistoryEvent);
+                    if(historyEvent is HistoryEvent) {
+                        array:push(targetHistory.labelsAdded,historyEvent);
                     } else {
-                        log:printError("Error occured while converting to HistoryChange type", err = historyChange);
+                        log:printError("Error occured while converting to HistoryEvent type", err = historyEvent);
                     }
                 }                
             } else {
@@ -517,11 +517,11 @@ function convertJSONToHistoryType(json sourceJsonHistory) returns @tainted Histo
             var removedLabels = srcJsonHisMap["labelsRemoved"];
             if(removedLabels is json[]) {
                 foreach var removedLabel in removedLabels {
-                    var historyChange = removedLabel.cloneWithType(HistoryChange);
-                    if(historyChange is HistoryChange) {
-                        array:push(targetHistory.labelsRemoved,historyChange);
+                    var historyEvent = removedLabel.cloneWithType(HistoryEvent);
+                    if(historyEvent is HistoryEvent) {
+                        array:push(targetHistory.labelsRemoved,historyEvent);
                     } else {
-                        log:printError("Error occured while converting to HistoryChange type", err = historyChange);
+                        log:printError("Error occured while converting to HistoryEvent type", err = historyEvent);
                     }
                 }                
             } else {

--- a/endpoint.bal
+++ b/endpoint.bal
@@ -729,6 +729,38 @@ public client class Client {
         string threadId = let var tid = jsonSendDraftResponse.threadId in tid is string ? tid : EMPTY_STRING;
         return [identity, threadId];
     }
+
+    # Set up or update a push notification watch on the given user mailbox.
+    #
+    # + userId - The user's email address. The special value **me** can be used to indicate the authenticated user.
+    # + requestBody - The request body contains data with the following structure of JSON representation:
+    #                   `{`
+    #                   `   "labelIds": [`
+    #                   `       string`
+    #                   `    ],`
+    #                   `    "labelFilterAction": enum (LabelFilterAction),`
+    #                   `    "topicName": string`
+    #                   `       }`
+    # + return - If successful, returns WatchResponse. Else returns error.
+    remote function watch(string userId, json requestBody) returns WatchResponse | error {
+        http:Request request = new;
+        string watchPath = USER_RESOURCE+userId+WATCH;
+        request.setJsonPayload(requestBody);
+        http:Response httpResponse = <http:Response> check self.gmailClient->post(watchPath, request);
+        json jsonWatchResponse = check handleResponse(httpResponse);
+        WatchResponse watchResponse = check jsonWatchResponse.cloneWithType(WatchResponse);
+        return watchResponse;
+    }
+
+    # Set up or update a push notification watch on the given user mailbox.
+    #
+    # + userId - The user's email address. The special value **me** can be used to indicate the authenticated user.
+    # + return - If successful, nothing will be returned. Else returns error.
+    remote function stop(string userId) returns error? {
+        http:Request request = new;
+        string stopPath = USER_RESOURCE+userId+STOP;
+        http:Response httpResponse = <http:Response> check self.gmailClient->post(stopPath, request);
+    }    
 }
 
 # Object for Spreadsheet configuration.

--- a/modules/listener/Module.md
+++ b/modules/listener/Module.md
@@ -1,0 +1,203 @@
+# Ballerina Gmail Listener Module
+
+Connects to Gmail Listener using Ballerina.
+
+# Module Overview
+
+The Gmail Listener Ballerina Connector provides the capability to listen the push notification for changes to Gmail mailboxes. The Gmail Listener Ballerina Connector supports to listen the changes of Gmail mailboxes such as receiving new message, receiving new thread, adding new label to a message, adding star to a message, removing label to a message, removing star to a message and receiving a new attachment with following trigger methods: `onMailboxChanges`, `onNewEmail`, `onNewThread`, `onNewLabeledEmail`, `onNewStaredEmail`, `onLabelRemovedEmail`,`onStarRemovedEmail`, `onNewAttachment`.
+
+
+# Prerequisites:
+
+* Java 11 Installed
+Java Development Kit (JDK) with version 11 is required.
+
+* Download the Ballerina [distribution](https://ballerinalang.org/downloads/)
+Ballerina Swan Lake Alpha 2 is required.
+
+* Instantiate the connector by giving authentication details in the HTTP client config. The HTTP client config has built-in support for BasicAuth and OAuth 2.0. Gmail uses OAuth 2.0 to authenticate and authorize requests. The Gmail connector can be minimally instantiated in the HTTP client config using the client ID, client secret, and refresh token.
+    * Client ID
+    * Client Secret
+    * Refresh Token
+    * Refresh URL
+
+## Obtaining Tokens
+
+1. Visit [Google API Console](https://console.developers.google.com), click **Create Project**, and follow the wizard to create a new project.
+2. Go to **Library** from the left side menu. In the search bar enter required API/Service name(Eg: Gmail). Then select required service and click **Enable** button.
+3. Go to **Credentials -> OAuth consent screen**, enter a product name to be shown to users, and click **Save**.
+4. On the **Credentials** tab, click **Create credentials** and select **OAuth client ID**. 
+5. Select an application type, enter a name for the application, and specify a redirect URI (enter https://developers.google.com/oauthplayground if you want to use 
+[OAuth 2.0 playground](https://developers.google.com/oauthplayground) to receive the authorization code and obtain the refresh token). 
+6. Click **Create**. Your client ID and client secret appear. 
+7. In a separate browser window or tab, visit [OAuth 2.0 playground](https://developers.google.com/oauthplayground), select the required Gmail scopes, and then click **Authorize APIs**.
+
+8. When you receive your authorization code, click **Exchange authorization code for tokens** to obtain the refresh token.
+
+## Create push topic and subscription
+To use Gmail Listener connector, a topic and a subscription should be configured.
+
+1. Enable Cloud Pub/Sub API for your project which is created in [Google API Console](https://console.developers.google.com).
+2. Go to [Google Cloud Pub/Sub API management console](https://console.cloud.google.com/cloudpubsub/topic/list)  and create a topic([You can follow the instructions here](https://cloud.google.com/pubsub/docs/quickstart-console) and a subscription to that topic. The subscription should be a pull subscription in this case ([Find mode details here](https://cloud.google.com/pubsub/docs/subscriber))).
+3. For the push subscription , an endpoint URL should be given to push the notification. This URL is the URL where the gmail listener service runs. This should be in `https`  format. (If the service runs in localhost, then ngrok can be used to get an `https` URL).
+4. Grant publish right on your topic. [To do this, see the instructions here](https://developers.google.com/gmail/api/guides/push#grant_publish_rights_on_your_topic).
+
+5. Once you have done the above steps, get your topic name (It will be in the format of `projects/<YOUR_PROJECT_NAME>topics/<YOUR_TOPIC_NAME>`) from your console and give it to the `Config.toml` file as `topicName`.
+
+
+## Add project configurations file
+Add the project configuration file by creating a `Config.toml` file under the root path of the project structure.
+This file should have following configurations. Add the token obtained in the previous step to the `Config.toml` file.
+
+```
+[ballerinax.googleapis_gmail]
+refreshToken = "enter your refresh token here"
+clientId = "enter your client id here"
+clientSecret = "enter your client secret here"
+port = "enter the port where your listener runs"
+topicName = "enter your push topic name"
+
+```
+
+# Compatibility
+
+| Ballerina Language Versions  | Gmail API Version |
+|:----------------------------:|:-----------------:|
+|  Swan Lake Alpha 2           |   v1              |
+
+# Quickstart(s):
+
+## Working with Gmail Listener
+
+### Step 1: Import Gmail and Gmail Listener Ballerina Library
+First, import the ballerinax/googleapis_gmail and ballerinax/googleapis_gmail.'listener module into the Ballerina project.
+```ballerina
+    import ballerinax/googleapis_gmail as gmail;
+    import ballerinax/googleapis_gmail.'listener as gmailListener;
+```
+
+### Step 2: Initialize the Gmail Client and Gmail Listener
+In order for you to use the Gmail Listener Endpoint, first you need to create a Gmail Client endpoint and a Gmail Listener endpoint.
+```ballerina
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+```
+Then the endpoint triggers can be invoked as `var response = gmailEventListener->triggerName(arguments)`.
+
+
+# Samples
+
+### On New Email
+
+Triggers when a new e-mail appears in the mail inbox.
+
+```ballerina
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewEmail(response);
+            if(triggerResponse is gmail:Message[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var msg in triggerResponse {
+                        log:print("Message ID: "+msg.id + " Thread ID: "+ msg.threadId+ " Snippet: "+msg.snippet);
+                    }
+                }
+            }
+        }
+    }     
+}
+```
+
+### On New Labeled Email
+
+Triggers when you label an email.
+
+```ballerina
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewLabeledEmail(response);
+            if(triggerResponse is gmailListener:ChangedLabel[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var changedLabel in triggerResponse {
+                        log:print("Message ID: "+ changedLabel.message.id + " Changed Label ID: "
+                            +changedLabel.changedLabelId[0]);
+                    }
+                }
+            }
+        }
+    }     
+}
+```
+More samples are available at "https://github.com/ballerina-platform/module-ballerinax-googleapis.gmail/tree/master/samples/listener".

--- a/modules/listener/constants.bal
+++ b/modules/listener/constants.bal
@@ -14,8 +14,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Holds the types of changes occured in Mailbox..
+#Represents available triggers
+public enum Trigger {
+    ON_NEW_EMAIL,
+    ON_NEW_THREAD,
+    ON_NEW_LABELED,
+    ON_NEW_STARED,
+    ON_LABEL_REMOVED,
+    ON_STAR_REMOVED,
+    ON_NEW_ATTACHMENT
+}
+
+# Holds the value of label Id "STARRED".
 const string STARRED = "STARRED";
+#Holds the value of label Id "INBOX".
+const string INBOX = "INBOX";
 
 # Holds the value "me". Used as current authenticated userId.
 const string ME = "me";

--- a/modules/listener/constants.bal
+++ b/modules/listener/constants.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Holds the types of changes occured in Mailbox..
+const string STARRED = "STARRED";
+
+# Holds the value "me". Used as current authenticated userId.
+const string ME = "me";

--- a/modules/listener/listener.bal
+++ b/modules/listener/listener.bal
@@ -19,7 +19,7 @@ import ballerina/log;
 import ballerina/lang.array;
 import ballerinax/googleapis_gmail as gmail;
 
-# Listener to observe changes in mailbox.   
+# Listener for Gmail Connector.   
 public class Listener {
     private string startHistoryId = "";
     private string userId = ME;
@@ -58,6 +58,11 @@ public class Listener {
         return self.httpListener.immediateStop();
     }
 
+    # Returns MailboxHistoryPage when a change happens in Gmail mailbox.
+    # 
+    # + caller - http:Caller for acknowleding to the request received
+    # + request - http:Request that contains event related data
+    # + return - If success, returns MailboxHistoryPage record, else error
     public function onMailboxChanges(http:Caller caller, http:Request request) 
                                         returns gmail:MailboxHistoryPage| error {
         var payload = request.getJsonPayload();
@@ -72,6 +77,10 @@ public class Listener {
         return mailboxHistoryPage;
     }
 
+    # Returns new messages which are received in Gmail mailbox.
+    #
+    # + mailboxHistoryPage - MailboxHistoryPage record which is returened in a mailbox change
+    # + return - If success, returns array of gmail:Message record, else error
     public function onNewEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns gmail:Message[] | error {
         gmail:Message[] messages = [];
         foreach var history in mailboxHistoryPage.historyRecords {
@@ -86,6 +95,10 @@ public class Listener {
         return messages;
     }
 
+    # Returns new mail threads which are received in Gmail mailbox.
+    #
+    # + mailboxHistoryPage - MailboxHistoryPage record which is returened in a mailbox change
+    # + return - If success, returns array of gmail:MailThread record, else error
     public function onNewThread(gmail:MailboxHistoryPage mailboxHistoryPage) returns gmail:MailThread[] | error {
         gmail:MailThread[] threads = [];
         foreach var history in mailboxHistoryPage.historyRecords {
@@ -102,6 +115,10 @@ public class Listener {
         return threads;
     }
 
+    # Returns messages when a new label is added to messages.
+    #
+    # + mailboxHistoryPage - MailboxHistoryPage record which is returened in a mailbox change
+    # + return - If success, returns array of ChangedLabel record, else error
     public function onNewLabeledEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns ChangedLabel[] | error {
         ChangedLabel[] changedLabels = [];
         foreach var history in mailboxHistoryPage.historyRecords {
@@ -119,6 +136,10 @@ public class Listener {
         return changedLabels;
     }
 
+    # Returns messages when a new star is added to messages.
+    #
+    # + mailboxHistoryPage - MailboxHistoryPage record which is returened in a mailbox change
+    # + return - If success, returns array of gmail:Message record, else error
     public function onNewStaredEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns gmail:Message[] | error {
         gmail:Message[] messages = [];
         foreach var history in mailboxHistoryPage.historyRecords {
@@ -139,6 +160,10 @@ public class Listener {
         return messages;
     }
 
+    # Returns messages when a label is removed from messages.
+    #
+    # + mailboxHistoryPage - MailboxHistoryPage record which is returened in a mailbox change
+    # + return - If success, returns array of ChangedLabel record, else error
     public function onLabelRemovedEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns ChangedLabel[] | error {
         ChangedLabel[] changedLabels = [];
         foreach var history in mailboxHistoryPage.historyRecords {
@@ -156,6 +181,10 @@ public class Listener {
         return changedLabels;
     }    
 
+    # Returns messages when a star is removed from messages.
+    #
+    # + mailboxHistoryPage - MailboxHistoryPage record which is returened in a mailbox change
+    # + return - If success, returns array of gmail:Message record, else error
     public function onStarRemovedEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns gmail:Message[] | error {
         gmail:Message[] messages = [];
         foreach var history in mailboxHistoryPage.historyRecords {
@@ -176,6 +205,10 @@ public class Listener {
         return messages;
     }
 
+    # Returns Attchment details when a new attachment is recieved to mailbox.
+    #
+    # + mailboxHistoryPage - MailboxHistoryPage record which is returened in a mailbox change
+    # + return - If success, returns array of gmail:MessageBodyPart record, else error
     public function onNewAttachment(gmail:MailboxHistoryPage mailboxHistoryPage) 
                                         returns gmail:MessageBodyPart[] |error {
         gmail:MessageBodyPart[] attachments = [];                                  

--- a/modules/listener/listener.bal
+++ b/modules/listener/listener.bal
@@ -1,0 +1,178 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+import ballerina/lang.array;
+import ballerinax/googleapis_gmail as gmail;
+
+# Listener to observe changes in mailbox.   
+public class Listener {
+    private string startHistoryId = "";
+    private string userId = ME;
+    private json requestBody;
+    private gmail:Client gmailClient;
+    private http:Listener httpListener;
+
+    public isolated function init(int port, gmail:Client gmailClient, json requestBody) {
+        self.httpListener = checkpanic new (port);
+        self.gmailClient = gmailClient;
+        self.requestBody = requestBody;
+    }
+
+    public function attach(service object {} s, string[]|string? name = ()) returns error? {
+        gmail:WatchResponse  response = check self.gmailClient->watch(self.userId, self.requestBody);
+        self.startHistoryId = response.historyId;
+        log:print("Starting History ID: "+ self.startHistoryId);
+        return self.httpListener.attach(s, name);
+    }
+
+    public isolated function detach(service object {} s) returns error? {
+        return self.httpListener.detach(s);
+    }
+
+    public isolated function 'start() returns error? {
+        return self.httpListener.'start();
+    }
+
+    public function gracefulStop() returns error? {
+        var response = check self.gmailClient->stop(self.userId);
+        log:print("Watch Stopped = "+response.toString());
+        return self.httpListener.gracefulStop();
+    }
+
+    public isolated function immediateStop() returns error? {
+        return self.httpListener.immediateStop();
+    }
+
+    public function getMailboxChanges(http:Caller caller, http:Request request) returns gmail:MailboxHistoryPage| error {
+        var payload = request.getJsonPayload();
+        var response = caller->respond(http:STATUS_OK);
+        var  mailboxHistoryPage =  self.gmailClient->listHistory(self.userId, self.startHistoryId);
+        if(mailboxHistoryPage is gmail:MailboxHistoryPage) {
+            self.startHistoryId = mailboxHistoryPage.historyId;
+            log:print("Next History ID = "+self.startHistoryId);
+        } else {
+            log:printError("Error occured while getting history.",err= mailboxHistoryPage);
+        }        
+        return mailboxHistoryPage;
+    }
+
+    public function getNewEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns gmail:Message[] | error {
+        gmail:Message[] messages = [];
+        foreach var history in mailboxHistoryPage.historyRecords {
+            gmail:HistoryChange[] messagesAdded = history.messagesAdded;
+            if(messagesAdded.length()>0) {
+                foreach var messageAdded in messagesAdded {                    
+                    gmail:Message message = check self.gmailClient->readMessage(ME, messageAdded.message.id);
+                    array:push(messages, message);
+                }
+            }
+        }
+        return messages;
+    }
+
+    public function getNewThread(gmail:MailboxHistoryPage mailboxHistoryPage) returns gmail:MailThread[] | error {
+        gmail:MailThread[] threads = [];
+        foreach var history in mailboxHistoryPage.historyRecords {
+            gmail:HistoryChange[] messagesAdded = history.messagesAdded;
+            if(messagesAdded.length()>0) {
+                foreach var messageAdded in messagesAdded {    
+                    if(messageAdded.message.id == messageAdded.message.threadId) {               
+                        gmail:MailThread thread = check self.gmailClient->readThread(ME, messageAdded.message.threadId);
+                        array:push(threads, thread);
+                    }
+                }
+            }
+        }
+        return threads;
+    }
+
+    public function getNewLabeledEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns LabelChange[] | error {
+        LabelChange[] labelchanges = [];
+        foreach var history in mailboxHistoryPage.historyRecords {
+            gmail:HistoryChange[] labelsAdded = history.labelsAdded;
+            if(labelsAdded.length()>0) {
+                foreach var labelAdded in labelsAdded {
+                    LabelChange labelChangedMsg ={ message: {},changedLabelId: []};
+                    labelChangedMsg.changedLabelId = labelAdded.labelIds;
+                    gmail:Message message = check self.gmailClient->readMessage(ME, labelAdded.message.id);
+                    labelChangedMsg.message = message;
+                    array:push(labelchanges, labelChangedMsg);
+                }
+            }            
+        }
+        return labelchanges;
+    }
+
+    public function getNewStaredEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns gmail:Message[] | error {
+        gmail:Message[] messages = [];
+        foreach var history in mailboxHistoryPage.historyRecords {
+            gmail:HistoryChange[] labelsAdded = history.labelsAdded;
+            if(labelsAdded.length()>0) {
+                foreach var labelAdded in labelsAdded {
+                    foreach var label in labelAdded.labelIds {
+                        match label{
+                            STARRED =>{
+                                gmail:Message message = check self.gmailClient->readMessage(ME, labelAdded.message.id);
+                                array:push(messages, message);
+                            }
+                        }
+                    }
+                }
+            }            
+        }
+        return messages;
+    }
+
+    public function getLabelRemovedEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns LabelChange[] | error {
+        LabelChange[] labelchanges = [];
+        foreach var history in mailboxHistoryPage.historyRecords {
+            gmail:HistoryChange[] labelsRemoved = history.labelsRemoved;
+            if(labelsRemoved.length()>0) {
+                foreach var labelRemoved in labelsRemoved {
+                    LabelChange labelChangedMsg ={ message: {},changedLabelId: []};
+                    labelChangedMsg.changedLabelId = labelRemoved.labelIds;
+                    gmail:Message message = check self.gmailClient->readMessage(ME, labelRemoved.message.id);
+                    labelChangedMsg.message = message;
+                    array:push(labelchanges, labelChangedMsg);
+                }
+            }            
+        }
+        return labelchanges;
+    }    
+
+    public function getStarRemovedEmail(gmail:MailboxHistoryPage mailboxHistoryPage) returns gmail:Message[] | error {
+        gmail:Message[] messages = [];
+        foreach var history in mailboxHistoryPage.historyRecords {
+            gmail:HistoryChange[] labelsRemoved = history.labelsRemoved;
+            if(labelsRemoved.length()>0) {
+                foreach var labelRemoved in labelsRemoved {
+                    foreach var label in labelRemoved.labelIds {
+                        match label{
+                            STARRED =>{
+                                gmail:Message message = check self.gmailClient->readMessage(ME, labelRemoved.message.id);
+                                array:push(messages, message);
+                            }
+                        }
+                    }
+                }
+            }            
+        }
+        return messages;
+    }
+    
+}

--- a/modules/listener/types.bal
+++ b/modules/listener/types.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/googleapis_gmail as gmail;
+
+# Represents label changed message.
+#
+# + message - The message which affected by label change  
+# + changedLabelId - The changed label id of the message
+public type LabelChange record {
+    gmail:Message message;
+    string[] changedLabelId;
+};

--- a/modules/listener/types.bal
+++ b/modules/listener/types.bal
@@ -20,7 +20,7 @@ import ballerinax/googleapis_gmail as gmail;
 #
 # + message - The message which affected by label change  
 # + changedLabelId - The changed label id of the message
-public type LabelChange record {
+public type ChangedLabel record {
     gmail:Message message;
     string[] changedLabelId;
 };

--- a/samples/listener/trigger_on_label_removed_email.bal
+++ b/samples/listener/trigger_on_label_removed_email.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/log;
 import ballerinax/googleapis_gmail as gmail;

--- a/samples/listener/trigger_on_label_removed_email.bal
+++ b/samples/listener/trigger_on_label_removed_email.bal
@@ -1,0 +1,42 @@
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onLabelRemovedEmail(response);
+            if(triggerResponse is gmailListener:ChangedLabel[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var changedLabel in triggerResponse {
+                        log:print("Message ID: "+ changedLabel.message.id + " Changed Label ID: "
+                            +changedLabel.changedLabelId[0]);
+                    }
+                }
+            }
+        }
+    }     
+}

--- a/samples/listener/trigger_on_new_attachment.bal
+++ b/samples/listener/trigger_on_new_attachment.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/log;
 import ballerinax/googleapis_gmail as gmail;

--- a/samples/listener/trigger_on_new_attachment.bal
+++ b/samples/listener/trigger_on_new_attachment.bal
@@ -1,0 +1,41 @@
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewAttachment(response);
+            if(triggerResponse is gmail:MessageBodyPart[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var attachment in triggerResponse {
+                        log:print("Attachment Size: "+attachment.size);
+                    }
+                }
+            }
+        }
+    }     
+}

--- a/samples/listener/trigger_on_new_email.bal
+++ b/samples/listener/trigger_on_new_email.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/log;
 import ballerinax/googleapis_gmail as gmail;

--- a/samples/listener/trigger_on_new_email.bal
+++ b/samples/listener/trigger_on_new_email.bal
@@ -1,0 +1,41 @@
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewEmail(response);
+            if(triggerResponse is gmail:Message[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var msg in triggerResponse {
+                        log:print("Message ID: "+msg.id + " Thread ID: "+ msg.threadId+ " Snippet: "+msg.snippet);
+                    }
+                }
+            }
+        }
+    }     
+}

--- a/samples/listener/trigger_on_new_labeled_email.bal
+++ b/samples/listener/trigger_on_new_labeled_email.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/log;
 import ballerinax/googleapis_gmail as gmail;

--- a/samples/listener/trigger_on_new_labeled_email.bal
+++ b/samples/listener/trigger_on_new_labeled_email.bal
@@ -1,0 +1,42 @@
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewLabeledEmail(response);
+            if(triggerResponse is gmailListener:ChangedLabel[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var changedLabel in triggerResponse {
+                        log:print("Message ID: "+ changedLabel.message.id + " Changed Label ID: "
+                            +changedLabel.changedLabelId[0]);
+                    }
+                }
+            }
+        }
+    }     
+}

--- a/samples/listener/trigger_on_new_stared_email.bal
+++ b/samples/listener/trigger_on_new_stared_email.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/log;
 import ballerinax/googleapis_gmail as gmail;

--- a/samples/listener/trigger_on_new_stared_email.bal
+++ b/samples/listener/trigger_on_new_stared_email.bal
@@ -1,0 +1,41 @@
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewStaredEmail(response);
+            if(triggerResponse is gmail:Message[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var msg in triggerResponse {
+                        log:print("Message ID: "+msg.id + " Thread ID: "+ msg.threadId+ " Snippet: "+msg.snippet);
+                    }
+                }
+            }
+        }
+    }     
+}

--- a/samples/listener/trigger_on_new_thread.bal
+++ b/samples/listener/trigger_on_new_thread.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/log;
 import ballerinax/googleapis_gmail as gmail;

--- a/samples/listener/trigger_on_new_thread.bal
+++ b/samples/listener/trigger_on_new_thread.bal
@@ -1,0 +1,41 @@
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onNewThread(response);
+            if(triggerResponse is gmail:MailThread[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var thread in triggerResponse {
+                        log:print("Thread ID: "+ thread.id);
+                    }
+                }
+            }
+        }
+    }     
+}

--- a/samples/listener/trigger_on_star_removed_email.bal
+++ b/samples/listener/trigger_on_star_removed_email.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/http;
 import ballerina/log;
 import ballerinax/googleapis_gmail as gmail;

--- a/samples/listener/trigger_on_star_removed_email.bal
+++ b/samples/listener/trigger_on_star_removed_email.bal
@@ -1,0 +1,41 @@
+import ballerina/http;
+import ballerina/log;
+import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis_gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string topicName = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmail:Client gmailClient = new (gmailConfig);
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailClient, topicName);
+
+service / on gmailEventListener {
+    resource function post web(http:Caller caller, http:Request req) {
+        var payload = req.getJsonPayload();
+        var response = gmailEventListener.onMailboxChanges(caller , req);
+        if(response is gmail:MailboxHistoryPage) {
+            var triggerResponse = gmailEventListener.onStarRemovedEmail(response);
+            if(triggerResponse is gmail:Message[]) {
+                if (triggerResponse.length()>0){
+                    //Write your logic here.....
+                    foreach var msg in triggerResponse {
+                        log:print("Message ID: "+msg.id + " Thread ID: "+ msg.threadId+ " Snippet: "+msg.snippet);
+                    }
+                }
+            }
+        }
+    }     
+}

--- a/tests/main_test.bal
+++ b/tests/main_test.bal
@@ -18,26 +18,29 @@ import ballerina/log;
 import ballerina/os;
 import ballerina/test;
 
+configurable string testRecipient = os:getEnv("RECIPIENT");
+configurable string testSender = os:getEnv("SENDER");
+configurable string testCc = os:getEnv("CC");
+configurable string testAttachmentPath = os:getEnv("ATTACHMENT_PATH");
+configurable string attachmentContentType = os:getEnv("ATTACHMENT_CONTENT_TYPE");
+configurable string inlineImagePath = os:getEnv("INLINE_IMAGE_PATH");
+configurable string inlineImageName = os:getEnv("INLINE_IMAGE_NAME");
+configurable string imageContentType = os:getEnv("IMAGE_CONTENT_TYPE");
+configurable string refreshToken = os:getEnv("REFRESH_TOKEN");
+configurable string clientId = os:getEnv("CLIENT_ID");
+configurable string clientSecret = os:getEnv("CLIENT_SECRET");
+
 GmailConfiguration gmailConfig = {
     oauthClientConfig: {
         refreshUrl: REFRESH_URL,
-        refreshToken: os:getEnv("REFRESH_TOKEN"),
-        clientId: os:getEnv("CLIENT_ID"),
-        clientSecret: os:getEnv("CLIENT_SECRET")
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret 
     }
 };
 
 Client gmailClient = new(gmailConfig);
 
-//---------------Provide the following in the conf file before running the tests-------------------//
-string testRecipient = os:getEnv("RECIPIENT");
-string testSender = os:getEnv("SENDER");
-string testCc = os:getEnv("CC");
-string testAttachmentPath = os:getEnv("ATTACHMENT_PATH");
-string attachmentContentType = os:getEnv("ATTACHMENT_CONTENT_TYPE");
-string inlineImagePath = os:getEnv("INLINE_IMAGE_PATH");
-string inlineImageName = os:getEnv("INLINE_IMAGE_NAME");
-string imageContentType = os:getEnv("IMAGE_CONTENT_TYPE");
 
 //---------------Do not change the following variables-----------------------//
 string testUserId = "me";

--- a/types.bal
+++ b/types.bal
@@ -283,10 +283,19 @@ public type MailboxHistoryPage record {
 public type History record {
     string id = "";
     Message[] messages = [];
-    Message[] messagesAdded = [];
-    Message[] messagesDeleted = [];
-    Message[] labelsAdded = [];
-    Message[] labelsRemoved = [];
+    HistoryChange[] messagesAdded = [];
+    HistoryChange[] messagesDeleted = [];
+    HistoryChange[] labelsAdded = [];
+    HistoryChange[] labelsRemoved = [];
+};
+
+# Represents changes of messages in history record.
+# 
+# + message - The message changed  
+# + labelIds - The label ids of the message  
+public type HistoryChange record {
+    Message message = {};
+    string [] labelIds = [];
 };
 
 # Represents a draft email in user's mailbox.
@@ -296,4 +305,13 @@ public type History record {
 public type Draft record {
     string id = "";
     Message message = {};
+};
+
+# Represents a watch response.
+#
+# + historyId - The ID of the mailbox's current history record.
+# + expiration - When Gmail will stop sending notifications for mailbox updates (epoch millis) - (int64 format). 
+public type WatchResponse record {
+    string historyId = "";
+    string expiration = "";
 };

--- a/types.bal
+++ b/types.bal
@@ -283,17 +283,17 @@ public type MailboxHistoryPage record {
 public type History record {
     string id = "";
     Message[] messages = [];
-    HistoryChange[] messagesAdded = [];
-    HistoryChange[] messagesDeleted = [];
-    HistoryChange[] labelsAdded = [];
-    HistoryChange[] labelsRemoved = [];
+    HistoryEvent[] messagesAdded = [];
+    HistoryEvent[] messagesDeleted = [];
+    HistoryEvent[] labelsAdded = [];
+    HistoryEvent[] labelsRemoved = [];
 };
 
 # Represents changes of messages in history record.
 # 
 # + message - The message changed  
 # + labelIds - The label ids of the message  
-public type HistoryChange record {
+public type HistoryEvent record {
     Message message = {};
     string [] labelIds = [];
 };


### PR DESCRIPTION
## Purpose
> This PR will add listener support for gmail connector. Samples and documentation for listener module also added in this PR. Resolves https://github.com/wso2-enterprise/choreo/issues/2691.

## Goals
> Add listener module for gmail connector.
## Approach
> Gmail watch API used to watch mailbox. Google cloud Pub/Sub is used to set up push topic and subscription.

## User stories
> A user wants to get information when ever a change happens to his/her mailbox. Eg: when a new mail arrive. The changes should be notified to user immediately.

## Release note
> Listener support is added to Gmail Connector.

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Samples added into samples directory. 

## Related PRs
> N/A

## Migrations (if applicable)
> N/A
## Test environment
> JDK 11, Swan Lake Alpha2 
 
## Learning
> N/A