### PR TITLE
Migrate to SLAlpha5 and update module notation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 #Config file
 Config.toml
 # Modules
-/modules/googleapis_gmail
+/modules/googleapis.gmail
 
 # BlueJ files
 *.ctxt
@@ -42,6 +42,7 @@ temp.bal.ballerina/
 target/
 .DS_Store
 *Ballerina.lock
+gmail/modules/gmail/resources
 gmail/resources
 
 # Ignore Gradle project-specific cache directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 script:
-  - wget http://dist-dev.ballerina.io/downloads/swan-lake-alpha4/ballerina-linux-installer-x64-swan-lake-alpha4.deb
-  - sudo dpkg -i ballerina-linux-installer-x64-swan-lake-alpha4.deb
+  - wget http://dist-dev.ballerina.io/downloads/swan-lake-alpha5/ballerina-linux-installer-x64-swan-lake-alpha5.deb
+  - sudo dpkg -i ballerina-linux-installer-x64-swan-lake-alpha5.deb
   - sudo apt-get install -f
   - bal --version
   - bal build -c --skip-tests

--- a/Readme.md
+++ b/Readme.md
@@ -84,7 +84,7 @@ Refresh Token.
 
 * Java 11 Installed <br/> Java Development Kit (JDK) with version 11 is required.
 
-* Ballerina SLAlpha4 Installed <br/> Ballerina Swan Lake Alpha 4 is required.
+* Ballerina SLAlpha5 Installed <br/> Ballerina Swan Lake Alpha 5 is required.
 
 # Supported Versions & Limitations
 
@@ -93,8 +93,8 @@ Refresh Token.
 |                                   | Version               |
 |-----------------------------------|-----------------------|
 | Gmail API Version                 | v1                    |
-| Google Cloud Pub/Sub API Version                 | v1                    |
-| Ballerina Language                | Swan Lake Alpha 4     |
+| Google Cloud Pub/Sub API Version  | v1                    |
+| Ballerina Language                | Swan Lake Alpha 5     |
 | Java Development Kit (JDK)        | 11                    |
 
 # Limitations
@@ -105,9 +105,9 @@ Refresh Token.
 
 ## Send a text message
 ### Step 1: Import the Gmail module
-First, import the `ballerinax/googleapis_gmail` module into the Ballerina project.
+First, import the `ballerinax/googleapis.gmail` module into the Ballerina project.
 ```ballerina
-import ballerinax/googleapis_gmail;
+import ballerinax/googleapis.gmail;
 ```
 
 
@@ -214,7 +214,7 @@ if (delete is error) {
 # Samples
 ## Messages/Emails
 Message in a Gmail account represents a single email. With the Gmail API, you can only create and delete messages, and 
-apply labels to them, all other data is immutable and can’t be changed. The `ballerinax/googleapis_gmail` module 
+apply labels to them, all other data is immutable and can’t be changed. The `ballerinax/googleapis.gmail` module 
 contains operations to send emails in Text and HTML formats with attachments and inline images. It supports searching 
 and reading emails in Gmail using Gmail filters. The module also supports trashing, un-trashing, deleting, and modifying 
 emails.
@@ -451,7 +451,7 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 ## Working with Threads
 A thread is a collection of messages that represents a conversation. Gmail creates threads automatically as users send 
 and receive emails. With the Gmail API, you can delete threads and insert messages into existing threads. The 
-`ballerinax/googleapis_gmail` module contains operations to read, search, trash, un-trash, modify and delete 
+`ballerinax/googleapis.gmail` module contains operations to read, search, trash, un-trash, modify and delete 
 email threads in Gmail. Unlike messages, threads cannot be created, only deleted. Messages can, however, be inserted 
 into a thread.
 
@@ -599,7 +599,7 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ## Working with Drafts
 A Draft is an unsent message that with the label DRAFT. When sent, it’s automatically replaced with a matching message 
-that has the label SENT. The `ballerinax/googleapis_gmail` module contains operations to search, read, delete, create, 
+that has the label SENT. The `ballerinax/googleapis.gmail` module contains operations to search, read, delete, create, 
 update and send drafts in Gmail.
 
 ### Create draft
@@ -770,7 +770,7 @@ Labels are used to categorize and organize messages and threads in a Gmail accou
 relationship with messages and threads, meaning that a message or thread can have any number of labels applied to it, 
 and a label can be applied to any number of messages and threads. Gmail account itself provide a set of pre defined 
 labels that you can use including INBOX, SPAM, DRAFT, STARRED, and IMPORTANT. But you can create custom labels too.
-The `ballerinax/googleapis_gmail` module contains operations to list, read, create, update and delete labels in Gmail. 
+The `ballerinax/googleapis.gmail` module contains operations to list, read, create, update and delete labels in Gmail. 
 
 ### Create label
 Labels are used to categorize messages and threads within the user's mailbox. This sample shows how to create a new 
@@ -874,7 +874,7 @@ if (deleteLabelResponse == true) {
 Sample is available at: https://github.com/ballerina-platform/module-ballerinax-googleapis.gmail/blob/master/samples/labels/delete_label.bal
 
 ## Working with User Profiles
-Gmail API can be used to get the information about a Gmail profile of a user. The `ballerinax/googleapis_gmail` module 
+Gmail API can be used to get the information about a Gmail profile of a user. The `ballerinax/googleapis.gmail` module 
 supports this operation. This sample shows how you can get information about the profile of the authorized user using the
 ballerina connector. 
 
@@ -894,7 +894,7 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ## Working with Mailbox History
 Gmail API provide capability to list the history of all changes to the given mailbox. History results are returned in 
-chronological order. The `ballerinax/googleapis_gmail` module supports this by providing operations to lists the history 
+chronological order. The `ballerinax/googleapis.gmail` module supports this by providing operations to lists the history 
 of changes to the user's mailbox. This sample shows how you can get the mailbox history of the authorized user as a list.
 The operation needs to give a starting history ID from where the list of history will be obtained from that point
 onwards. 
@@ -942,11 +942,11 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 ## Quickstart(s):
 
 ### Step 1: Import Gmail and Gmail Listener Ballerina Library
-First, import the ballerinax/googleapis_gmail and ballerinax/googleapis_gmail.'listener module into the Ballerina project.
+First, import the ballerinax/googleapis.gmail and ballerinax/googleapis.gmail.'listener module into the Ballerina project.
 
 ```ballerina
-    import ballerinax/googleapis_gmail as gmail;
-    import ballerinax/googleapis_gmail.'listener as gmailListener;
+    import ballerinax/googleapis.gmail as gmail;
+    import ballerinax/googleapis.gmail.'listener as gmailListener;
 ```
 
 ### Step 2: Initialize the Gmail Listener
@@ -993,8 +993,8 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -1030,8 +1030,8 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -1067,8 +1067,8 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -1103,8 +1103,8 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -1140,8 +1140,8 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -1177,8 +1177,8 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -1214,8 +1214,8 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -1255,7 +1255,7 @@ service / on gmailEventListener {
 
         > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-2. Download and install [Ballerina Swan Lake Alpha4](https://ballerina.io/). 
+2. Download and install [Ballerina Swan Lake Alpha5](https://ballerina.io/). 
 
 3. Download and install gradle.
 
@@ -1280,7 +1280,7 @@ To build java libraries execute the following command.
 
 ### Build ballerina connector.
 
-Execute the commands below to build from the source after installing Ballerina Swan Lake Alpha4.
+Execute the commands below to build from the source after installing Ballerina Swan Lake Alpha5.
 
 1. To build the library:
 ```shell script

--- a/gmail/Ballerina.toml
+++ b/gmail/Ballerina.toml
@@ -1,17 +1,18 @@
 [package]
 org = "ballerinax"
-name = "googleapis_gmail"
-version = "0.99.6"
+name = "googleapis.gmail"
+version = "0.99.7"
+export= ["googleapis.gmail", "googleapis.gmail.listener"]
 authors = ["Ballerina"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-googleapis.gmail"
-keywords = ["gmail","email"]
+keywords = ["gmail","email","google","mail"]
 license = ["Apache-2.0"]
 
 [build-options]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.99.6.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.99.7.jar"
 groupId = "org.ballerinalang.googleapis.gmail"
 artifactId = "java-wrapper"
-version = "0.99.6"
+version = "0.99.7"

--- a/gmail/Dependencies.toml
+++ b/gmail/Dependencies.toml
@@ -1,52 +1,52 @@
 [[dependency]]
 org = "ballerina"
 name = "io"
-version = "0.6.0-alpha7"
+version = "0.6.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "jballerina.java.arrays"
-version = "0.10.0-alpha7"
+version = "0.10.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "mime"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-alpha7"
+version = "1.1.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "uuid"
-version = "0.10.0-alpha7"
+version = "0.10.0-alpha8"
 
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-alpha8"
+version = "2.0.0-alpha9"
 
 [[dependency]]
 org = "ballerina"
 name = "task"
-version = "2.0.0-alpha8"
+version = "2.0.0-alpha9"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-alpha7"
+version = "0.8.0-alpha8"
 
 [[dependency]]
 org = "ballerina"

--- a/gmail/Module.md
+++ b/gmail/Module.md
@@ -41,13 +41,13 @@ gmail:Client gmailClient = new (gmailConfig);
 
 | Ballerina Language Versions  | Gmail API Version |
 |:----------------------------:|:-----------------:|
-|  Swan Lake Alpha 4           |   v1              |
+|  Swan Lake Alpha 5           |   v1              |
 
 ## Sample
 
 ```ballerina
 import ballerina/io;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/gmail/Package.md
+++ b/gmail/Package.md
@@ -41,13 +41,13 @@ gmail:Client gmailClient = new (gmailConfig);
 
 | Ballerina Language Versions  | Gmail API Version |
 |:----------------------------:|:-----------------:|
-|  Swan Lake Alpha 4           |   v1              |
+|  Swan Lake Alpha 5           |   v1              |
 
 ## Example Code
 This code sample represents sending a new text message from one Gmail user to another one. Here, the receiver which needs to receive carbon copy is also mentioned.
 ```ballerina
 import ballerina/io;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {
@@ -101,7 +101,7 @@ The Gmail Listener Ballerina Connector provides the capability to listen the pus
 Java Development Kit (JDK) with version 11 is required.
 
 * Download the Ballerina [distribution](https://ballerinalang.org/downloads/)
-Ballerina Swan Lake Alpha 4 is required.
+Ballerina Swan Lake Alpha 5 is required.
 
 * Instantiate the connector by giving authentication details in the HTTP client config. The HTTP client config has built-in support for BasicAuth and OAuth 2.0. Gmail uses OAuth 2.0 to authenticate and authorize requests. The Gmail connector can be minimally instantiated in the HTTP client config using the client ID, client secret, and refresh token.
     * Client ID
@@ -128,7 +128,7 @@ Add the project configuration file by creating a `Config.toml` file under the ro
 This file should have following configurations. Add the token obtained in the previous step to the `Config.toml` file.
 
 ```
-[ballerinax.googleapis_gmail]
+[ballerinax.googleapis.gmail]
 refreshToken = "enter your refresh token here"
 clientId = "enter your client id here"
 clientSecret = "enter your client secret here"
@@ -144,17 +144,17 @@ pushEndpoint = "Listener endpoint"
 
 | Ballerina Language Versions  | Gmail API Version |
 |:----------------------------:|:-----------------:|
-|  Swan Lake Alpha 4           |   v1              |
+|  Swan Lake Alpha 5           |   v1              |
 
 # Quickstart(s):
 
 ## Working with Gmail Listener
 
 ### Step 1: Import Gmail and Gmail Listener Ballerina Library
-First, import the ballerinax/googleapis_gmail and ballerinax/googleapis_gmail.'listener module into the Ballerina project.
+First, import the ballerinax/googleapis.gmail and ballerinax/googleapis.gmail.'listener module into the Ballerina project.
 ```ballerina
-    import ballerinax/googleapis_gmail as gmail;
-    import ballerinax/googleapis_gmail.'listener as gmailListener;
+    import ballerinax/googleapis.gmail as gmail;
+    import ballerinax/googleapis.gmail.'listener as gmailListener;
 ```
 
 ### Step 2: Initialize the Gmail Listener
@@ -199,8 +199,8 @@ Triggers when a new e-mail appears in the mail inbox.
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -234,8 +234,8 @@ Triggers when you label an email.
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/gmail/constants.bal
+++ b/gmail/constants.bal
@@ -195,4 +195,4 @@ public const string TEXT_PLAIN = "text/plain";
 public const string TEXT_HTML = "text/html";
 
 // Error Codes
-const string GMAIL_ERROR_CODE = "(ballerinax/googleapis_gmail)GmailError";
+const string GMAIL_ERROR_CODE = "(ballerinax/googleapis.gmail)GmailError";

--- a/gmail/metadata/gmail.json
+++ b/gmail/metadata/gmail.json
@@ -3,7 +3,7 @@
         "name":"gmail",
         "displayName":"Gmail",
         "organization":"ballerinax",
-        "module":"googleapis_gmail",
+        "module":"googleapis.gmail",
         "icon":"gmail.png",
         "clients":[
             {

--- a/gmail/modules/listener/Dispatcher.bal
+++ b/gmail/modules/listener/Dispatcher.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 class Dispatcher {
     private boolean isOnNewEmail = false;
@@ -64,7 +64,7 @@ class Dispatcher {
         }
     }
 
-    function dispatch(gmail:MailboxHistoryPage mailboxHistoryPage) returns error? {
+    function dispatch(gmail:MailboxHistoryPage mailboxHistoryPage) returns @tainted error? {
         foreach var history in mailboxHistoryPage.historyRecords {
             gmail:HistoryEvent[] newMessages = history.messagesAdded;
             gmail:HistoryEvent[] addedlabels = history.labelsAdded;
@@ -108,7 +108,7 @@ class Dispatcher {
         }
     }
 
-    function dispatchNewMessage(gmail:HistoryEvent newMessage) returns error? {
+    function dispatchNewMessage(gmail:HistoryEvent newMessage) returns @tainted error? {
         gmail:Message message = check self.gmailClient->readMessage(ME,<@untainted>newMessage.message.id);
         if (self.isOnNewEmail) {
             check callOnNewEmail(self.httpService, message);
@@ -128,14 +128,14 @@ class Dispatcher {
         check callOnNewAttachment(self.httpService, mailAttachment);  
     }
 
-    function dispatchNewThread(gmail:HistoryEvent newMessage) returns error? {
+    function dispatchNewThread(gmail:HistoryEvent newMessage) returns @tainted error? {
         if(newMessage.message.id == newMessage.message.threadId) {               
             gmail:MailThread thread = check self.gmailClient->readThread(ME, <@untainted>newMessage.message.threadId);
             check callOnNewThread(self.httpService, thread);
         }
     }
 
-    function dispatchNewLabeled(gmail:HistoryEvent addedlabel) returns error? {
+    function dispatchNewLabeled(gmail:HistoryEvent addedlabel) returns @tainted error? {
         ChangedLabel changedLabeldMsg ={ message: {},changedLabelId: []};
         changedLabeldMsg.changedLabelId = addedlabel.labelIds;
         gmail:Message message = check self.gmailClient->readMessage(ME, <@untainted>addedlabel.message.id);
@@ -143,7 +143,7 @@ class Dispatcher {
         check callOnNewLabeledEmail(self.httpService, changedLabeldMsg);
     }
 
-    function dispatchStarredEmail(gmail:HistoryEvent addedlabel) returns error? {
+    function dispatchStarredEmail(gmail:HistoryEvent addedlabel) returns @tainted error? {
         foreach var label in addedlabel.labelIds {
             match label{
                 STARRED =>{
@@ -154,7 +154,7 @@ class Dispatcher {
         }
     }
 
-    function dispatchRemovedLabels(gmail:HistoryEvent removedLabel) returns error?{
+    function dispatchRemovedLabels(gmail:HistoryEvent removedLabel) returns @tainted error?{
         ChangedLabel changedLabeldMsg ={ message: {},changedLabelId: []};
         changedLabeldMsg.changedLabelId = removedLabel.labelIds;
         gmail:Message message = check self.gmailClient->readMessage(ME, <@untainted>removedLabel.message.id);
@@ -162,7 +162,7 @@ class Dispatcher {
         check callOnLabelRemovedEmail(self.httpService, changedLabeldMsg);
     }
 
-    function dispatchRemovedStar(gmail:HistoryEvent removedLabel) returns error? {
+    function dispatchRemovedStar(gmail:HistoryEvent removedLabel) returns @tainted error? {
         foreach var label in removedLabel.labelIds {
             match label{
                 STARRED =>{

--- a/gmail/modules/listener/Module.md
+++ b/gmail/modules/listener/Module.md
@@ -13,7 +13,7 @@ The Gmail Listener Ballerina Connector provides the capability to listen the pus
 Java Development Kit (JDK) with version 11 is required.
 
 * Download the Ballerina [distribution](https://ballerinalang.org/downloads/)
-Ballerina Swan Lake Alpha 4 is required.
+Ballerina Swan Lake Alpha 5 is required.
 
 * Instantiate the connector by giving authentication details in the HTTP client config. The HTTP client config has built-in support for BasicAuth and OAuth 2.0. Gmail uses OAuth 2.0 to authenticate and authorize requests. The Gmail connector can be minimally instantiated in the HTTP client config using the client ID, client secret, and refresh token.
     * Client ID
@@ -41,7 +41,7 @@ Add the project configuration file by creating a `Config.toml` file under the ro
 This file should have following configurations. Add the token obtained in the previous step to the `Config.toml` file.
 
 ```
-[ballerinax.googleapis_gmail]
+[ballerinax.googleapis.gmail]
 refreshToken = "enter your refresh token here"
 clientId = "enter your client id here"
 clientSecret = "enter your client secret here"
@@ -57,17 +57,17 @@ pushEndpoint = "Listener endpoint"
 
 | Ballerina Language Versions  | Gmail API Version |
 |:----------------------------:|:-----------------:|
-|  Swan Lake Alpha 4           |   v1              |
+|  Swan Lake Alpha 5           |   v1              |
 
 # Quickstart(s):
 
 ## Working with Gmail Listener
 
 ### Step 1: Import Gmail and Gmail Listener Ballerina Library
-First, import the ballerinax/googleapis_gmail and ballerinax/googleapis_gmail.'listener module into the Ballerina project.
+First, import the ballerinax/googleapis.gmail and ballerinax/googleapis.gmail.'listener module into the Ballerina project.
 ```ballerina
-    import ballerinax/googleapis_gmail as gmail;
-    import ballerinax/googleapis_gmail.'listener as gmailListener;
+    import ballerinax/googleapis.gmail as gmail;
+    import ballerinax/googleapis.gmail.'listener as gmailListener;
 ```
 
 ### Step 2: Initialize the Gmail Listener
@@ -112,8 +112,8 @@ Triggers when a new e-mail appears in the mail inbox.
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;
@@ -147,8 +147,8 @@ Triggers when you label an email.
 
 ```ballerina
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/gmail/modules/listener/constants.bal
+++ b/gmail/modules/listener/constants.bal
@@ -74,7 +74,7 @@ const string GETIAMPOLICY = ":getIamPolicy";
 # Holds the value for :setIamPolicy resource path.
 const string SETIAMPOLICY = ":setIamPolicy";
 # Holds the value Error code in listener.
-const string GMAIL_LISTENER_ERROR_CODE = "(ballerinax/googleapis_gmail) GmailListenerError";
+const string GMAIL_LISTENER_ERROR_CODE = "(ballerinax/googleapis.gmail) GmailListenerError";
 
 public enum Encoding {
     ENCODING_UNSPECIFIED,

--- a/gmail/modules/listener/http_service.bal
+++ b/gmail/modules/listener/http_service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 service class HttpService {
 

--- a/gmail/modules/listener/listener.bal
+++ b/gmail/modules/listener/listener.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 # Listener for Gmail Connector.
 @display {label: "Gmail Listener"} 

--- a/gmail/modules/listener/natives.bal
+++ b/gmail/modules/listener/natives.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 import ballerina/jballerina.java;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 isolated function callOnNewEmail(SimpleHttpService httpService, gmail:Message message) returns error?
     = @java:Method {

--- a/gmail/modules/listener/types.bal
+++ b/gmail/modules/listener/types.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 # Represents label changed message.
 #

--- a/gmail/tests/README.md
+++ b/gmail/tests/README.md
@@ -2,7 +2,7 @@
 
 | Ballerina Language Version | Gmail API Version |  
 |:--------------------------:|:-----------------:|
-| Swan Lake Alpha 4          |   v1              |
+| Swan Lake Alpha 5          |   v1              |
 
 ### Prerequisites
 
@@ -38,7 +38,7 @@ In order to run the tests, the user will need to have a Gmail account and create
 #### Config.toml
 ```ballerina
 
-[ballerinax.googleapis_gmail]
+[ballerinax.googleapis.gmail]
 //Give the credentials and tokens for the authorized user
 refreshToken = "enter your refresh token here"
 clientId = "enter your client id here"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.googleapis.gmail
-version=0.99.6
-ballerinaLangVersion=2.0.0-alpha5
+version=0.99.7
+ballerinaLangVersion=2.0.0-alpha8-20210423-135000-530658ec

--- a/java-wrapper/src/main/java/module-info.java
+++ b/java-wrapper/src/main/java/module-info.java
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-module io.ballerinax.googleapis.gmail {
+module org.ballerinalang.googleapis.gmail {
     requires io.ballerina.lang;
     requires io.ballerina.runtime;
 }

--- a/samples/drafts/create_draft.bal
+++ b/samples/drafts/create_draft.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/drafts/delete_draft.bal
+++ b/samples/drafts/delete_draft.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/drafts/list_drafts.bal
+++ b/samples/drafts/list_drafts.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/drafts/read_draft.bal
+++ b/samples/drafts/read_draft.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/drafts/send_draft.bal
+++ b/samples/drafts/send_draft.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/drafts/update_draft.bal
+++ b/samples/drafts/update_draft.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/get_user_profile.bal
+++ b/samples/get_user_profile.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/labels/create_label.bal
+++ b/samples/labels/create_label.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/labels/delete_label.bal
+++ b/samples/labels/delete_label.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/labels/list_label.bal
+++ b/samples/labels/list_label.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/labels/update_label.bal
+++ b/samples/labels/update_label.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/list_history.bal
+++ b/samples/list_history.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/listener/trigger_on_label_removed_email.bal
+++ b/samples/listener/trigger_on_label_removed_email.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/samples/listener/trigger_on_new_attachment.bal
+++ b/samples/listener/trigger_on_new_attachment.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/samples/listener/trigger_on_new_email.bal
+++ b/samples/listener/trigger_on_new_email.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/samples/listener/trigger_on_new_labeled_email.bal
+++ b/samples/listener/trigger_on_new_labeled_email.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/samples/listener/trigger_on_new_starred_email.bal
+++ b/samples/listener/trigger_on_new_starred_email.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/samples/listener/trigger_on_new_thread.bal
+++ b/samples/listener/trigger_on_new_thread.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/samples/listener/trigger_on_star_removed_email.bal
+++ b/samples/listener/trigger_on_star_removed_email.bal
@@ -15,8 +15,8 @@
 // under the License.
 
 import ballerina/log;
-import ballerinax/googleapis_gmail as gmail;
-import ballerinax/googleapis_gmail.'listener as gmailListener;
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
 
 configurable string refreshToken = ?;
 configurable string clientId = ?;

--- a/samples/messages/delete_message.bal
+++ b/samples/messages/delete_message.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/get_attachment.bal
+++ b/samples/messages/get_attachment.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/list_messages.bal
+++ b/samples/messages/list_messages.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/modify_message.bal
+++ b/samples/messages/modify_message.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/read_message_with_attachments.bal
+++ b/samples/messages/read_message_with_attachments.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/read_text_message.bal
+++ b/samples/messages/read_text_message.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/send_html_message.bal
+++ b/samples/messages/send_html_message.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/send_text_message.bal
+++ b/samples/messages/send_text_message.bal
@@ -17,7 +17,7 @@
 import ballerina/log;
 import ballerina/os;
 //import ballerina/io;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/trash_message.bal
+++ b/samples/messages/trash_message.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/messages/untrash_message.bal
+++ b/samples/messages/untrash_message.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/threads/delete_thread.bal
+++ b/samples/threads/delete_thread.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/threads/list_threads.bal
+++ b/samples/threads/list_threads.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/threads/modify_thread.bal
+++ b/samples/threads/modify_thread.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/threads/read_one_thread.bal
+++ b/samples/threads/read_one_thread.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {

--- a/samples/threads/trash_untrash_thread.bal
+++ b/samples/threads/trash_untrash_thread.bal
@@ -16,7 +16,7 @@
 
 import ballerina/log;
 import ballerina/os;
-import ballerinax/googleapis_gmail as gmail;
+import ballerinax/googleapis.gmail as gmail;
 
 gmail:GmailConfiguration gmailConfig = {
     oauthClientConfig: {


### PR DESCRIPTION
## Purpose
* Migrate the connector to Swan Lake Alpha 5: Resolves https://github.com/wso2-enterprise/choreo/issues/3752.
* Update `_ ` module notation to `.` notation 

## Goals
> Migrate Gmail connector to Swan Lake Alpha 5.