### PR TITLE
Fix having empty file name  and empty estimatedSize for an attachment

### DIFF
--- a/gmail/types.bal
+++ b/gmail/types.bal
@@ -107,9 +107,9 @@ public type AttachmentPath record {
 # + headerDate - Email header **Date**
 # + headerContentType - Email header **ContentType**
 # + mimeType - MIME type of the top level message part
-# + plainTextBodyPart - MIME Message Part with text/plain content type
-# + htmlBodyPart - MIME Message Part with text/html content type
-# + inlineImgParts - MIME Message Parts with inline images with the image/* content type
+# + emailBodyInText - MIME Message Part with text/plain content type
+# + emailBodyInHTML - MIME Message Part with text/html content type
+# + emailInlineImages - MIME Message Parts with inline images with the image/* content type
 # + msgAttachments - MIME Message Parts of the message consisting the attachments
 public type Message record {
     string threadId = "";
@@ -129,9 +129,9 @@ public type Message record {
     string headerDate = "";
     string headerContentType = "";
     string mimeType = "";
-    MessageBodyPart plainTextBodyPart = {};
-    MessageBodyPart htmlBodyPart = {};
-    MessageBodyPart[] inlineImgParts = [];
+    MessageBodyPart emailBodyInText = {};
+    MessageBodyPart emailBodyInHTML = {};
+    MessageBodyPart[] emailInlineImages = [];
     MessageBodyPart[] msgAttachments = [];
 };
 

--- a/gmail/utils.bal
+++ b/gmail/utils.bal
@@ -34,7 +34,7 @@ function getFilePartsFromPayload(json messagePayload, MessageBodyPart[] msgAttac
                                  MessageBodyPart[] inlineMessageImages) returns 
                                  @tainted [MessageBodyPart[], MessageBodyPart[]] {
     MessageBodyPart[] attachmentParts = msgAttachments;
-    MessageBodyPart[] inlineImgParts = inlineMessageImages;
+    MessageBodyPart[] emailInlineImages = inlineMessageImages;
     string disposition = getDispostionFromPayload(messagePayload);
 
     string messagePayloadMimeType = let var mimeType = messagePayload.mimeType in mimeType is string ? mimeType : 
@@ -45,7 +45,7 @@ function getFilePartsFromPayload(json messagePayload, MessageBodyPart[] msgAttac
         attachmentParts[attachmentParts.length()] = convertJSONToMsgBodyType(messagePayload);
     } else if (isMimeType(messagePayloadMimeType, IMAGE_ANY) && (disposition == INLINE)) {
         //Get the inline message body part
-        inlineImgParts[inlineImgParts.length()] = convertJSONToMsgBodyType(messagePayload);
+        emailInlineImages[emailInlineImages.length()] = convertJSONToMsgBodyType(messagePayload);
     } //Else if is any multipart/*
     else if (isMimeType(messagePayloadMimeType, MULTIPART_ANY) && (messagePayload.parts !== ())) {
         json|error messageParts = messagePayload.parts;
@@ -56,13 +56,13 @@ function getFilePartsFromPayload(json messagePayload, MessageBodyPart[] msgAttac
                 foreach json part in messagePartsArr {
                     //Recursively check each ith child mime part
                     [MessageBodyPart[], MessageBodyPart[]] parts = getFilePartsFromPayload(part, attachmentParts,
-                        inlineImgParts);
-                    [attachmentParts, inlineImgParts] = parts;
+                        emailInlineImages);
+                    [attachmentParts, emailInlineImages] = parts;
                 }
             }
         }
     }
-    return [attachmentParts, inlineImgParts];
+    return [attachmentParts, emailInlineImages];
 }
 
 # Gets the body MIME messagePart with the specified content type (excluding attachments and inline images)


### PR DESCRIPTION
## Purpose
> Fixing the issue: Gmail client provides the empty values for the readMessagefunction attachments.
Fixes wso2-enterprise/choreo#4157
## Goals
> Improving the Gmail connector 

## Approach
1. Fixed the data mapping
2. Rename Message record field names.

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 11, Ballerina Swan Lake Alpha5