### PR TITLE
Fix issue on returning invalid Base64 data string by getAttachement function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,11 @@ target/
 *Ballerina.lock
 gmail/modules/gmail/resources
 gmail/resources
+.ballerina
 
 # Ignore Gradle project-specific cache directory
 .gradle
 
 # Ignore Gradle build output directory
 build
+

--- a/gmail/Dependencies.toml
+++ b/gmail/Dependencies.toml
@@ -47,3 +47,10 @@ version = "2.0.0-beta.1"
 org = "ballerina"
 name = "os"
 version = "0.8.0-beta.1"
+
+[[dependency]]
+org = "ballerina"
+name = "regex"
+version = "0.7.0-beta.1"
+
+

--- a/gmail/data_mappings.bal
+++ b/gmail/data_mappings.bal
@@ -16,6 +16,7 @@
 
 import ballerina/lang.array;
 import ballerina/lang.'int;
+import ballerina/regex;
 import ballerina/log;
 
 type mapJson map<json>;
@@ -132,9 +133,18 @@ isolated function convertJSONToMsgBodyType(json sourceMessagePartJsonObject) ret
 isolated function convertJSONToMsgBodyAttachment(json sourceMessageBodyJsonObject) returns MessageBodyPart {
     return {
         fileId: let var fileId = sourceMessageBodyJsonObject.attachmentId in fileId is string ? fileId : EMPTY_STRING,
-        body: let var body = sourceMessageBodyJsonObject.data in body is string ? body : EMPTY_STRING,
+        body: getFormattedBase64Body(sourceMessageBodyJsonObject),
         size: let var size = sourceMessageBodyJsonObject.size in size is int ? size.toString() : EMPTY_STRING
     };
+}
+
+# Format received base64 data string to the valid format.
+# + sourceMessageBodyJsonObject - `json` message body object
+# + return - Returns attachment body with valid Base64 encoded
+isolated function getFormattedBase64Body(json sourceMessageBodyJsonObject)  returns string {
+    string formattedBody = let var body = sourceMessageBodyJsonObject.data in body is string ? body : EMPTY_STRING;
+    formattedBody = regex:replaceAll(formattedBody, DASH_SYMBOL, PLUS_SYMBOL);
+    return regex:replaceAll(formattedBody, UNDERSCORE_SYMBOL, FORWARD_SLASH_SYMBOL);
 }
 
 # Transforms mail thread JSON object into MailThread type.


### PR DESCRIPTION
## Purpose
> Fixing the issue on returning invalid Base64 String by getAttchement function
Fixes wso2-enterprise/choreo#4426

## Goals
> Fixing the issue on attachment body Base64 format

## Approach
1. Added Base64 string formatting function
2. Updated dependencies
3.  Updated .gitignore file

## Automation tests
 - Unit tests 
   > done
 - Integration tests
   > done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ballerina Swan Lake Beta 1 SNAPSHOT, JDK 11