### PR TITLE
Add service account authorization in listener

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,7 @@ Refresh Token.
 
 * A Gmail Account with access <br/> https://support.google.com/mail/answer/56256?hl=en
 
-* New project with `Gmail API` enabled on the API Console. If you want to use **`Listener`**, then enable `Cloud Pub/Sub API` too.
+* New project with `Gmail API` enabled on the API Console. If you want to use **`Listener`**, then enable `Cloud Pub/Sub API` or user setup service account with pubsub admin role.
     - Visit [Google API Console](https://console.developers.google.com), click **Create Project**, and follow the wizard 
     to create a new project.
 
@@ -81,6 +81,7 @@ Refresh Token.
     - When you receive your authorization code, click **Exchange authorization code for tokens** to obtain the refresh 
     token and access token.
 
+* If you want to user service account in listener authorization. [Create a service account](https://developers.google.com/identity/protocols/oauth2/service-account#creatinganaccount) with pubsub admin and download the p12 key file.
 
 * Java 11 Installed <br/> Java Development Kit (JDK) with version 11 is required.
 
@@ -941,7 +942,10 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
 ## Quickstart(s):
 
-### Step 1: Import Gmail and Gmail Listener Ballerina Library
+### Using Google pubsub scope authorization.
+If you are able to authorize the pubsub scope, the you can follow all these steps to create a listener.
+
+#### Step 1: Import Gmail and Gmail Listener Ballerina Library
 First, import the ballerinax/googleapis.gmail and ballerinax/googleapis.gmail.'listener module into the Ballerina project.
 
 ```ballerina
@@ -949,7 +953,7 @@ First, import the ballerinax/googleapis.gmail and ballerinax/googleapis.gmail.'l
     import ballerinax/googleapis.gmail.'listener as gmailListener;
 ```
 
-### Step 2: Initialize the Gmail Listener
+#### Step 2: Initialize the Gmail Listener
 In order for you to use the Gmail Listener Endpoint, first you need to create a Gmail Listener endpoint.
 ```ballerina
 configurable string refreshToken = ?;
@@ -972,7 +976,7 @@ listener gmailListener:Listener gmailEventListener = new(port, gmailConfig,  pro
 
 
 ```
-### Step 3: Write service with required trigger 
+#### Step 3: Write service with required trigger 
 The Listener triggers can be invoked by using a service.
 ```ballerina
 service / on gmailEventListener {
@@ -981,9 +985,56 @@ service / on gmailEventListener {
    }   
 }
 ```
+### Using Google service account
+If you prefer to use only gmail scopes in your tokens, then you can use a service account to do listener operations along with your gmail tokens. For that you need to do the **step 2** as following method
+
+#### Step 2: Initialize the Gmail Listener
+In order for you to use the Gmail Listener Endpoint, first you need to create a Gmail Listener endpoint.
+```ballerina
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string project = ?;
+configurable string pushEndpoint = ?;
+
+configurable string issuer = ?;
+configurable string aud = ?;
+configurable string keyId = ?;
+configurable string path = ?;
+configurable string password = ?;
+configurable string keyAlias = ?;
+configurable string keyPassword = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmailListener:GmailListenerConfiguration listenerConfig = {authConfig: {
+        issuer: issuer,
+        audience: aud,
+        customClaims: {"sub": issuer},
+        keyId: keyId,
+        signatureConfig: {config: {
+                keyStore: {
+                    path: path,
+                    password: password
+                },
+                keyAlias: keyAlias,
+                keyPassword: keyPassword
+            }}
+    }};
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailConfig,  project, pushEndpoint, listenerConfig);
+```
 
 ## Samples
-Folowing are the available samples for Gmail Listener connector.
+Following are the available samples for Gmail Listener connector.
 
 ### Trigger for new email
 

--- a/gmail/modules/listener/Module.md
+++ b/gmail/modules/listener/Module.md
@@ -23,6 +23,8 @@ Ballerina Swan Lake Alpha 5 is required.
 
 ## Obtaining Tokens
 
+If you want to use **`Listener`**, then enable `Cloud Pub/Sub API` or user setup service account with pubsub admin role.
+
 1. Visit [Google API Console](https://console.developers.google.com), click **Create Project**, and follow the wizard to create a new project.
 2. Go to **Library** from the left side menu. In the search bar enter required API/Service name(Eg: Gmail, Cloud Pub/Sub). Then select required service and click **Enable** button.
 3. Go to **Credentials -> OAuth consent screen**, enter a product name to be shown to users, and click **Save**.
@@ -30,11 +32,9 @@ Ballerina Swan Lake Alpha 5 is required.
 5. Select an application type, enter a name for the application, and specify a redirect URI (enter https://developers.google.com/oauthplayground if you want to use 
 [OAuth 2.0 playground](https://developers.google.com/oauthplayground) to receive the authorization code and obtain the refresh token). 
 6. Click **Create**. Your client ID and client secret appear. 
-7. In a separate browser window or tab, visit [OAuth 2.0 playground](https://developers.google.com/oauthplayground), select the required Gmail scopes and `https://www.googleapis.com/auth/pubsub` scope of `Cloud Pub/Sub API v1`, and then click **Authorize APIs**.
-
+7. In a separate browser window or tab, visit [OAuth 2.0 playground](https://developers.google.com/oauthplayground), select the required Gmail scopes and `https://www.googleapis.com/auth/pubsub` scope of `Cloud Pub/Sub API v1`, and then click **Authorize APIs**. 
+If you want to use only Gmail scopes token then you can use service account configurations without  `Cloud Pub/Sub API v1` scope. [Create a service account](https://developers.google.com/identity/protocols/oauth2/service-account#creatinganaccount) with pubsub admin and download the p12 key file.
 8. When you receive your authorization code, click **Exchange authorization code for tokens** to obtain the refresh token.
-
-
 
 ## Add project configurations file
 Add the project configuration file by creating a `Config.toml` file under the root path of the project structure.
@@ -46,11 +46,19 @@ refreshToken = "enter your refresh token here"
 clientId = "enter your client id here"
 clientSecret = "enter your client secret here"
 port = "enter the port where your listener runs"
-topicName = "enter your push topic name"
-subscriptionName = "enter your subscription name"
 project = "enter your project name"
 pushEndpoint = "Listener endpoint"
+```
 
+Add following configurations if you use service account in the configurations.
+```
+issuer = "enter the email address of the service account."
+aud = "https://pubsub.googleapis.com/"
+keyId = "enter service account's private key ID"
+path = "Enter the path of p12 key"
+password = "password"
+keyAlias = "key alias name"
+keyPassword = "key password"
 ```
 
 # Compatibility
@@ -63,14 +71,16 @@ pushEndpoint = "Listener endpoint"
 
 ## Working with Gmail Listener
 
-### Step 1: Import Gmail and Gmail Listener Ballerina Library
+#### Step 1: Import Gmail and Gmail Listener Ballerina Library
 First, import the ballerinax/googleapis.gmail and ballerinax/googleapis.gmail.'listener module into the Ballerina project.
 ```ballerina
     import ballerinax/googleapis.gmail as gmail;
     import ballerinax/googleapis.gmail.'listener as gmailListener;
 ```
+### Using Google pubsub scope authorization.
+If you are able to authorize the pubsub scope, the you can follow all these steps to create a listener.
 
-### Step 2: Initialize the Gmail Listener
+#### Step 2: Initialize the Gmail Listener
 In order for you to use the Gmail Listener Endpoint, first you need to create a Gmail Listener endpoint.
 ```ballerina
 configurable string refreshToken = ?;
@@ -90,10 +100,8 @@ gmail:GmailConfiguration gmailConfig = {
 
 listener gmailListener:Listener gmailEventListener = new(port, gmailConfig,  project, pushEndpoint);
 
-
-
 ```
-### Step 3: Write service with required trigger 
+#### Step 3: Write service with required trigger 
 The Listener triggers can be invoked by using a service.
 ```ballerina
 service / on gmailEventListener {
@@ -103,6 +111,53 @@ service / on gmailEventListener {
 }
 ```
 
+### Using Google service account
+If you prefer to use only gmail scopes in your tokens, then you can use a service account to do listener operations along with your gmail tokens. For that you need to do the **step 2** as following method
+
+#### Step 2: Initialize the Gmail Listener
+In order for you to use the Gmail Listener Endpoint, first you need to create a Gmail Listener endpoint.
+```ballerina
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string project = ?;
+configurable string pushEndpoint = ?;
+
+configurable string issuer = ?;
+configurable string aud = ?;
+configurable string keyId = ?;
+configurable string path = ?;
+configurable string password = ?;
+configurable string keyAlias = ?;
+configurable string keyPassword = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+gmailListener:GmailListenerConfiguration listenerConfig = {authConfig: {
+        issuer: issuer,
+        audience: aud,
+        customClaims: {"sub": issuer},
+        keyId: keyId,
+        signatureConfig: {config: {
+                keyStore: {
+                    path: path,
+                    password: password
+                },
+                keyAlias: keyAlias,
+                keyPassword: keyPassword
+            }}
+    }};
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailConfig,  project, pushEndpoint, listenerConfig);
+```
 
 # Samples
 


### PR DESCRIPTION
## Purpose
Add service account authorization in listener. So pubsub operations will be done by Google application.

## Goals
Add service accounts authorization to use listener without pubsub scope consent in user authorization.
Fix https://github.com/wso2-enterprise/choreo/issues/4269

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Listener has to be configured in the following way to use service account.

```ballerina
configurable string refreshToken = ?;
configurable string clientId = ?;
configurable string clientSecret = ?;
configurable int port = ?;
configurable string project = ?;
configurable string pushEndpoint = ?;

configurable string issuer = ?;
configurable string aud = ?;
configurable string keyId = ?;
configurable string path = ?;
configurable string password = ?;
configurable string keyAlias = ?;
configurable string keyPassword = ?;

gmail:GmailConfiguration gmailConfig = {
    oauthClientConfig: {
        refreshUrl: gmail:REFRESH_URL,
        refreshToken: refreshToken,
        clientId: clientId,
        clientSecret: clientSecret
        }
};

gmailListener:GmailListenerConfiguration listenerConfig = {authConfig: {
        issuer: issuer,
        audience: aud,
        customClaims: {"sub": issuer},
        keyId: keyId,
        signatureConfig: {config: {
                keyStore: {
                    path: path,
                    password: password
                },
                keyAlias: keyAlias,
                keyPassword: keyPassword
            }}
    }};

listener gmailListener:Listener gmailEventListener = new(port, gmailConfig,  project, pushEndpoint, listenerConfig);
```

## Test environment
SLAlpha5, JDK11
 
## Learning
https://developers.google.com/identity/protocols/oauth2/service-account#creatinganaccount
https://developers.google.com/identity/protocols/oauth2/service-account#jwt-auth
https://ballerina.io/learn/user-guide/security/authentication-and-authorization/#http-client-authentication