### PR TITLE
Change watch request body from json to record

### DIFF
--- a/gmail/constants.bal
+++ b/gmail/constants.bal
@@ -196,3 +196,9 @@ public const string TEXT_HTML = "text/html";
 
 // Error Codes
 const string GMAIL_ERROR_CODE = "(ballerinax/googleapis.gmail)GmailError";
+
+#Holds values fro LabelFilterAction for watch request.
+public enum LabelFilterAction{
+    INCLUDE = "include",
+    EXCLUDE = "exclude"
+}

--- a/gmail/endpoint.bal
+++ b/gmail/endpoint.bal
@@ -837,11 +837,11 @@ public client class Client {
     # + return - If successful, returns WatchResponse. Else returns error.
     @display {label: "Watch mailbox changes"}
     remote isolated function watch(@display {label: "Mail address of user"} string userId, 
-                                   @display {label: "The request body for subscription"} json requestBody) 
+                                   @display {label: "The request body for subscription"} WatchRequestBody requestBody) 
                                    returns @tainted @display {label: "Watch result"} WatchResponse | error {
         http:Request request = new;
         string watchPath = USER_RESOURCE + userId + WATCH;
-        request.setJsonPayload(requestBody);
+        request.setJsonPayload(requestBody.toJson());
         http:Response httpResponse = <http:Response> check self.gmailClient->post(watchPath, request);
         json jsonWatchResponse = check handleResponse(httpResponse);
         WatchResponse watchResponse = check jsonWatchResponse.cloneWithType(WatchResponse);

--- a/gmail/modules/listener/listener.bal
+++ b/gmail/modules/listener/listener.bal
@@ -30,7 +30,7 @@ public class Listener {
     private string project;
     private string pushEndpoint;
 
-    private json requestBody;
+    private gmail:WatchRequestBody requestBody={topicName:""};
     private HttpService httpService;
     http:Client pubSubClient;
 
@@ -55,7 +55,7 @@ public class Listener {
         TopicSubscriptionDetail topicSubscriptionDetail = check createTopic(self.pubSubClient, project, pushEndpoint);        
         self.topicResource = topicSubscriptionDetail.topicResource;
         self.subscriptionResource = topicSubscriptionDetail.subscriptionResource;
-        self.requestBody = { labelIds: [INBOX], topicName: self.topicResource};
+        self.requestBody = {topicName: self.topicResource, labelIds: [INBOX], labelFilterAction : gmail:INCLUDE};
     }
 
     public isolated function attach(service object {} s, string[]|string? name = ()) returns @tainted error? {

--- a/gmail/modules/listener/util.bal
+++ b/gmail/modules/listener/util.bal
@@ -196,7 +196,7 @@ isolated function handleResponse(http:Response httpResponse) returns @tainted js
         }
     } else {
         error err = error(GMAIL_LISTENER_ERROR_CODE, message = 
-            "Error occurred while accessing the JSON payload of the response");
+            "Error occurred while accessing the JSON payload of the response", 'error= jsonResponse);
         return err;
     }
 }

--- a/gmail/types.bal
+++ b/gmail/types.bal
@@ -315,3 +315,15 @@ public type WatchResponse record {
     string historyId = "";
     string expiration = "";
 };
+
+# Represents a watch request body.
+#
+# + topicName - A fully qualified Google Cloud Pub/Sub API topic name to publish the events to. This topic name must
+#               already exist in Cloud Pub/Sub and you must have already granted gmail "publish" permission on it. 
+# + labelIds - Array of labelIds of gmail to restrict notifications about
+# + labelFilterAction - Filtering behavior of labelIds list specified.
+public type WatchRequestBody record {
+    string topicName;
+    string[] labelIds?;
+    LabelFilterAction labelFilterAction?;
+};


### PR DESCRIPTION
## Purpose
> Current requestBody parameter of watch remote method is in json type. This is not user friendly. Changing it to a record type will be user friendly.: Resolves https://github.com/wso2-enterprise/choreo/issues/4458.

## Goals
> Change watch request body from json to record type.