### PR TITLE
Change userId and sender as optional

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -153,7 +153,7 @@ The response from `sendMessage` is either a Message record or an `error` (if sen
 
 ```ballerina
 //Send the message.
-gmail:Message|error sendMessageResponse = checkpanic gmailClient->sendMessage(userId,messageRequest);
+gmail:Message|error sendMessageResponse = checkpanic gmailClient->sendMessage(messageRequest, userId = userId);
 
 if (sendMessageResponse is gmail:Message) {
     // If successful, print the message ID and thread ID.
@@ -171,7 +171,7 @@ The `readMessage` remote function reads messages. It returns the `Message` objec
 when unsuccessful.
 
 ```ballerina
-gmail:Message|error response = gmailClient->readMessage(userId, <@untainted>messageId);
+gmail:Message|error response = gmailClient->readMessage(<@untainted>messageId);
 
 if (response is gmail:Message) {
     io:println("Sent Message: " + response.toString());
@@ -186,7 +186,7 @@ the message before it automatically deletes by Gmail after 30 days. The operatio
 is trashed successfully. Else returns an `error`.
 
 ```ballerina
-gmail:Message|error trash = gmailClient->trashMessage(userId, sentMessageId);
+gmail:Message|error trash = gmailClient->trashMessage(sentMessageId);
 
 if (trash is gmail:Message) {
     log:printInfo("Successfully trashed the message");
@@ -200,7 +200,7 @@ The `deleteMessage` remote function deletes messages permanently from the Gmail 
 unsuccessful.
 
 ```ballerina    
-var delete = gmailClient->deleteMessage(userId, <@untainted>messageId);
+var delete = gmailClient->deleteMessage(<@untainted>messageId);
 
 if (delete is error) {
     io:println("Error: ", delete);
@@ -236,7 +236,7 @@ gmail:MessageRequest messageRequest = {
     contentType : gmail:TEXT_PLAIN
 };
 
-gmail:Message|error sendMessageResponse = checkpanic gmailClient->sendMessage(userId,messageRequest);
+gmail:Message|error sendMessageResponse = checkpanic gmailClient->sendMessage(messageRequest, userId = userId );
 
 if (sendMessageResponse is gmail:Message) {
     // If successful, print the message ID and thread ID.
@@ -256,8 +256,6 @@ what to send as data for an email. As the content type is HTML, the user must sp
 `MessageRequest` as **text/html**. This operation returns a Message record of the newly sent email. Else an `error`
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 string inlineImageName = "test_image.png";
 string htmlBody = "<h1> Email Test HTML Body </h1> <br/> <img src=\"cid:image-" + inlineImageName + "\">";
@@ -271,7 +269,7 @@ gmail:MessageRequest messageRequest = {
     contentType : gmail:TEXT_HTML
 };
 
-gmail:Message|error sendMessageResponse = gmailClient->sendMessage(userId, messageRequest);
+gmail:Message|error sendMessageResponse = gmailClient->sendMessage(messageRequest);
 if (sendMessageResponse is gmail:Message) {
     // If successful, print the message ID and thread ID.
     log:printInfo("Sent Message ID: " + sendMessageResponse.id);
@@ -312,13 +310,11 @@ This operation will return a `Message` if successful. Else return an `error`.
 
 ```ballerina
 
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // ID of the message to read.
 string sentMessageId = "<MESSAGE_ID>"; 
 
-gmail:Message|error response = gmailClient->readMessage(userId, sentMessageId);
+gmail:Message|error response = gmailClient->readMessage(sentMessageId);
 
 if (response is gmail:Message) {
     log:printInfo("Is message details available: ", status = response.id == sentMessageId);
@@ -337,13 +333,10 @@ of this operation is extracting the attachment and that can be accessed inside t
 
 ```ballerina
 
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
-
 // ID of the message to read
 string sentMessageId = "<MESSAGE_ID>";
 
-gmail:Message|error response = gmailClient->readMessage(userId, sentMessageId);
+gmail:Message|error response = gmailClient->readMessage(sentMessageId);
 
 if (response is gmail:Message) {
    if (response?.msgAttachments is gmail:MessageBodyPart[] ) {
@@ -365,8 +358,7 @@ successful. Else returns `error`.
 
 ```ballerina
 
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
+
 
 // ID of the message where attachment belongs to.
 string sentMessageId = "<MESSAGE_ID>"; 
@@ -374,7 +366,7 @@ string sentMessageId = "<MESSAGE_ID>";
 // ID of the attachment
 string readAttachmentFileId = "<ATTACHMENT_ID>";
 
-gmail:MessageBodyPart|error response = gmailClient->getAttachment(userId, sentMessageId, readAttachmentFileId);
+gmail:MessageBodyPart|error response = gmailClient->getAttachment(sentMessageId, readAttachmentFileId);
 
 if (response is gmail:MessageBodyPart) {
     log:printInfo("Attachment " + response.toString());
@@ -394,13 +386,11 @@ These two operations returns `Message` record if the operations are successful. 
 ```ballerina 
 // Moves the specified message to the trash.
 
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // ID of the message to trash or un-trash.
 string sentMessageId = "<MESSAGE_ID>"; 
 
-gmail:Message|error trash = gmailClient->trashMessage(userId, sentMessageId);
+gmail:Message|error trash = gmailClient->trashMessage(sentMessageId);
 
 if (trash is gmail:Message) {
     log:printInfo("Successfully trashed the message");
@@ -408,7 +398,7 @@ if (trash is gmail:Message) {
     log:printError("Failed to trash the message");
 }
 
-gmail:Message|error untrash = gmailClient->untrashMessage(userId, sentMessageId);
+gmail:Message|error untrash = gmailClient->untrashMessage(sentMessageId);
 
 if (untrash is gmail:Message) {
     log:printInfo("Successfully un-trashed the message");
@@ -425,13 +415,12 @@ message, delete message permanently deletes the message such that it cannot be r
 nothing if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
+
 
 // Id of the message to delete. This can be obtained from the response of create message.
 string sentMessageId = "<MESSAGE_ID>"; 
 
-error? delete = gmailClient->deleteMessage(userId, sentMessageId);
+error? delete = gmailClient->deleteMessage(sentMessageId);
     
 if (delete is error) {
     log:printError("Failed to delete the message");
@@ -455,14 +444,12 @@ search result. For this operation in the connector, you must also provide the **
 information. Returns a `MailThread` if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // ID of the thread to read.
 string sentMessageThreadId = "<THREAD_ID";
 
 // When given and format is METADATA, only include headers specified. Here, it will specify "Subject"
-gmail:MailThread|error thread = gmailClient->readThread(userId, sentMessageThreadId, format = gmail:FORMAT_METADATA, 
+gmail:MailThread|error thread = gmailClient->readThread(sentMessageThreadId, format = gmail:FORMAT_METADATA, 
     metadataHeaders = ["Subject"]);
     
 if (thread is gmail:MailThread) {
@@ -480,8 +467,6 @@ also provide the **ID of the thread** you want to read the information and **arr
 from the thread. Returns `MailThread` if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // ID of the thread to modify.
 string sentMessageThreadId = "<THREAD_ID"; 
@@ -489,7 +474,7 @@ string sentMessageThreadId = "<THREAD_ID";
 // Modify labels of the thread with thread id which was sent in testSendTextMessage
 
 log:printInfo("Add labels to a thread");
-gmail:MailThread|error response = gmailClient->modifyThread(userId, sentMessageThreadId, ["INBOX"], []);
+gmail:MailThread|error response = gmailClient->modifyThread(sentMessageThreadId, ["INBOX"], []);
 
 if (response is gmail:MailThread) {
     log:printInfo("Add labels to thread successfully: ", status = response.id == sentMessageThreadId);
@@ -498,7 +483,7 @@ if (response is gmail:MailThread) {
 }
 
 log:printInfo("Remove labels from a thread");
-response = gmailClient->modifyThread(userId, sentMessageThreadId, [], ["INBOX"]);
+response = gmailClient->modifyThread(sentMessageThreadId, [], ["INBOX"]);
 if (response is gmail:MailThread) {
     log:printInfo("Removed labels from thread successfully: ", status = response.id == sentMessageThreadId);
 } else {
@@ -514,11 +499,9 @@ result contains a `ThreadListPage` which inside it contains an array of `MailThr
 thread if operation is successful. Else returns an `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // Make includeSpamTrash false to exclude threads from SPAM and TRASH in the results.
-gmail:ThreadListPage|error threadList = gmailClient->listThreads(userId, filter = {includeSpamTrash: false, 
+gmail:ThreadListPage|error threadList = gmailClient->listThreads(filter = {includeSpamTrash: false, 
     labelIds: ["INBOX"]});
 
 if (threadList is gmail:ThreadListPage) {
@@ -542,14 +525,12 @@ of the connector. The operation has These two operations returns `MailThread` re
 returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // ID of the thread to trash or un-trash.
 string sentMessageThreadId = "<THREAD_ID";
 
 log:printInfo("Trash thread");
-gmail:MailThread|error trash = gmailClient->trashThread(userId, sentMessageThreadId);
+gmail:MailThread|error trash = gmailClient->trashThread(sentMessageThreadId);
 
 if (trash is gmail:MailThread) {
     log:printInfo("Successfully trashed the thread");
@@ -558,7 +539,7 @@ if (trash is gmail:MailThread) {
 } 
 
 log:printInfo("Un-trash thread");
-gmail:MailThread|error untrash = gmailClient->untrashThread(userId, sentMessageThreadId);
+gmail:MailThread|error untrash = gmailClient->untrashThread(sentMessageThreadId);
 
 if (untrash is gmail:MailThread) {
     log:printInfo("Successfully un-trashed the thread");
@@ -574,13 +555,11 @@ trashing a an email thread, delete thread permanently deletes the email thread s
 This operation returns nothing if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // ID of the thread to delete.
 string sentMessageThreadId = "<THREAD_ID"; 
 
-error? delete = gmailClient->deleteThread(userId, sentMessageThreadId);
+error? delete = gmailClient->deleteThread(sentMessageThreadId);
  
 if (delete is error) {
     log:printError("Failed to delete the thread");
@@ -602,8 +581,6 @@ This draft will be represented as an unsent messages with the DRAFT system label
 `string` representing the draft ID. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 // The ID of the thread the draft should sent to. this is optional.
 string sentMessageThreadId = "<THREAD_ID>";
 
@@ -616,7 +593,7 @@ gmail:MessageRequest messageRequest = {
     contentType : gmail:TEXT_PLAIN
 };
 
-string|error draftResponse = gmailClient->createDraft(userId, messageRequest, threadId = sentMessageThreadId);
+string|error draftResponse = gmailClient->createDraft(messageRequest, threadId = sentMessageThreadId);
 
 if (draftResponse is string) {
     log:printInfo("Successfully created draft: ", draftId = draftResponse);
@@ -634,8 +611,6 @@ return `string` representing the **ID of the draft** which is updated where, it 
 along with the request.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // The ID of the draft to update. This will be returned when a draft is created. 
 string createdDraftId = "<DRAFT_ID>";
@@ -655,7 +630,7 @@ string attachmentContentType = "text/plain";
 gmail:AttachmentPath[] attachments = [{attachmentPath: testAttachmentPath, mimeType: attachmentContentType}];
 newMessageRequest.attachmentPaths = attachments;
 
-string|error draftUpdateResponse = gmailClient->updateDraft(userId, createdDraftId, newMessageRequest);
+string|error draftUpdateResponse = gmailClient->updateDraft(createdDraftId, newMessageRequest);
 
 if (draftUpdateResponse is string) {
     log:printInfo("Successfully updated the draft: ", result = draftUpdateResponse);
@@ -671,13 +646,11 @@ connector, you must also provide the **ID of the draft** you want to read the in
 contain the data of the message which is saved as a draft if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // The ID of the existing draft we want to read.
 string createdDraftId = "<DRAFT_ID>"; 
 
-gmail:Draft|error draftReadResponse = gmailClient->readDraft(userId, createdDraftId);
+gmail:Draft|error draftReadResponse = gmailClient->readDraft(createdDraftId);
 
 if (draftReadResponse is gmail:Draft) {
     log:printInfo("Successfully read the draft: ", status = draftReadResponse.id == createdDraftId);
@@ -694,12 +667,10 @@ result contains a `DraftListPage` which inside it contains an array of `Draft` r
 draft if operation is successful. Else returns an `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 gmail:DraftSearchFilter searchFilter = {includeSpamTrash: false, maxResults: 10};
 
-gmail:DraftListPage|error msgList = gmailClient->listDrafts(userId, filter = searchFilter);
+gmail:DraftListPage|error msgList = gmailClient->listDrafts(filter = searchFilter);
 if (msgList is gmail:DraftListPage) {
     error? e = msgList.drafts.forEach(function (gmail:DraftList draft) {
         log:printInfo(draft.toString());
@@ -719,13 +690,11 @@ resources, delete of drafts immediately and permanently deletes the specified dr
 This operation returns nothing if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // The ID of the existing draft we want to delete.
 string createdDraftId = "<DRAFT_ID>"; 
 
-error? deleteResponse = gmailClient->deleteDraft(userId, createdDraftId);
+error? deleteResponse = gmailClient->deleteDraft(createdDraftId);
 
 if (deleteResponse is error) {
     log:printError("Failed to delete the draft");
@@ -743,13 +712,11 @@ return `error`. This is because, when the draft is sent, the draft is automatica
 updated ID is created with the SENT system label.
  
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // The ID of the existing draft we want to send.
 string createdDraftId = "<DRAFT_ID>"; 
 
-gmail:Message |error sendDraftResponse = gmailClient->sendDraft(userId, createdDraftId);
+gmail:Message |error sendDraftResponse = gmailClient->sendDraft(createdDraftId);
 
 if (sendDraftResponse is gmail:Message) {
     log:printInfo("Sent the draft successfully: ",
@@ -774,15 +741,13 @@ as the visibility is set to **labelShow** and the messages with this label will 
 **show**. This will return the ID of the created label as a `string` if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 string displayName = "Test";
 // The visibility of the label in the label list in the Gmail web interface.
 string labelVisibility = "labelShow";
 // The visibility of messages with this label in the message list in the Gmail web interface.
 string messageListVisibility = "show";
 
-string|error createLabelResponse = gmailClient->createLabel(userId, displayName, labelVisibility, 
+string|error createLabelResponse = gmailClient->createLabel(displayName, labelVisibility, 
     messageListVisibility);
 
 if (createLabelResponse is string) {
@@ -802,8 +767,6 @@ sample, the name of that label is changed to **updateTest** and additional prope
 colour is given as updates. This operation returns `Label` as result if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // The ID of an already created label that we want to update
 string createdLabelId = "<LABEL_ID>";
@@ -812,7 +775,7 @@ string updateName = "updateTest";
 string updateBgColor = "#16a766";
 string updateTxtColor = "#000000";
 
-gmail:Label|error updateLabelResponse = gmailClient->updateLabel(userId, createdLabelId, name = updateName,
+gmail:Label|error updateLabelResponse = gmailClient->updateLabel(createdLabelId, name = updateName,
     backgroundColor = updateBgColor, textColor = updateTxtColor);
 
 if (updateLabelResponse is gmail:Label) {
@@ -852,13 +815,11 @@ and permanently deletes the specified label and removes it from any messages and
 This operation returns nothing if successful. Else returns `error`.
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 
 // The ID of an already created label that we want to delete
 string createdLabelId = "<LABEL_ID>";
 
-error? deleteLabelResponse = gmailClient->deleteLabel(userId, createdLabelId);
+error? deleteLabelResponse = gmailClient->deleteLabel(createdLabelId);
      
 if (deleteLabelResponse is error) {
     log:printInfo("Failed to delete the message");
@@ -895,15 +856,13 @@ The operation needs to give a starting history ID from where the list of history
 onwards. 
 
 ```ballerina
-// The user's email address. The special value **me** can be used to indicate the authenticated user.
-string userId = "me";
 // TO get the history ID we have to get the history ID referring to message response.
 string sentMessageId = "<MESSAGE_ID>";
 
 // This operation returns history records after the specified `startHistoryId`. The supplied startHistoryId should be 
 // obtained from the historyId of a message, thread, or previous list response.
 string startHistoryId;
-var response = gmailClient->readMessage(userId, sentMessageId);
+var response = gmailClient->readMessage(sentMessageId);
 
 if (response is gmail:Message) {
 
@@ -912,7 +871,7 @@ if (response is gmail:Message) {
     // History types to be returned by the function
     string[] historyTypes = ["labelAdded", "labelRemoved", "messageAdded", "messageDeleted"];
 
-    gmail:MailboxHistoryPage|error listHistoryResponse = gmailClient->listHistory(userId, startHistoryId, 
+    gmail:MailboxHistoryPage|error listHistoryResponse = gmailClient->listHistory(startHistoryId, 
         historyTypes = historyTypes);
 
     if (listHistoryResponse is gmail:MailboxHistoryPage) {

--- a/gmail/Ballerina.toml
+++ b/gmail/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "googleapis.gmail"
-version = "0.99.8"
+version = "0.99.9"
 export= ["googleapis.gmail", "googleapis.gmail.listener"]
 authors = ["Ballerina"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-googleapis.gmail"
@@ -12,7 +12,7 @@ license = ["Apache-2.0"]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.99.8.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.99.9.jar"
 groupId = "org.ballerinalang.googleapis.gmail"
 artifactId = "java-wrapper"
-version = "0.99.8"
+version = "0.99.9"

--- a/gmail/Module.md
+++ b/gmail/Module.md
@@ -70,9 +70,8 @@ public function main(string... args) {
     contentType : gmail:TEXT_PLAIN
     };
 
-    string userId = "me";
     // Send the message.
-    var sendMessageResponse = gmailClient->sendMessage(userId, messageRequest);
+    var sendMessageResponse = gmailClient->sendMessage(messageRequest);
     if (sendMessageResponse is gmail:Message) {
         // If successful, print the message ID and thread ID.
         log:printInfo("Sent Message ID: "+ sendMessageResponse.id);

--- a/gmail/Package.md
+++ b/gmail/Package.md
@@ -72,10 +72,9 @@ gmail:MessageRequest messageRequest = {
     contentType : gmail:TEXT_PLAIN
 };
 
-    string userId = "me";
 
     // Send the message.
-    var sendMessageResponse = gmailClient->sendMessage(userId, messageRequest);
+    var sendMessageResponse = gmailClient->sendMessage(messageRequest);
     if (sendMessageResponse is gmail:Message) {
         // If successful, print the message ID and thread ID.
         log:printInfo("Sent Message ID: "+ sendMessageResponse.id);

--- a/gmail/constants.bal
+++ b/gmail/constants.bal
@@ -189,6 +189,8 @@ public const string FORMAT_RAW = "raw";
 public const string TEXT_PLAIN = "text/plain";
 # Holds value for message type **text/html**.
 public const string TEXT_HTML = "text/html";
+# Holds the value "me". Used as current authenticated userId.
+const string ME = "me";
 
 // Error Codes
 const string GMAIL_ERROR_CODE = "(ballerinax/googleapis.gmail)GmailError";

--- a/gmail/endpoint.bal
+++ b/gmail/endpoint.bal
@@ -22,6 +22,7 @@ import ballerina/http;
 @display {label: "Gmail", iconPath: "GmailLogo.png"}
 public client class Client {
     http:Client gmailClient;
+    //Here "me" denotes the current authenticated user.
     string userEmailId = ME;
 
     public isolated  function init(GmailConfiguration gmailConfig) {
@@ -90,7 +91,7 @@ public client class Client {
     # + userId - The user's email address. The special value **me** can be used to indicate the authenticated user.
     # + return - If successful, returns Message record of the successfully sent message. Else return error.
     @display {label: "Send Message"} 
-    remote function sendMessage(@display {label: "Message Request to Send"} MessageRequest message,
+    remote function sendMessage(@display {label: "Send Message"} MessageRequest message,
                                 @display {label: "Thread Id"} string? threadId = (),
                                 @display {label: "Email Address"} string? userId = ())
                                 returns @tainted @display {label: "Sent Message Response"} Message|error {

--- a/gmail/modules/listener/Dispatcher.bal
+++ b/gmail/modules/listener/Dispatcher.bal
@@ -118,7 +118,7 @@ class Dispatcher {
     }
 
     function dispatchNewMessage(gmail:HistoryEvent newMessage) returns @tainted error? {
-        gmail:Message message = check self.gmailClient->readMessage(ME,<@untainted>newMessage.message.id);
+        gmail:Message message = check self.gmailClient->readMessage(<@untainted>newMessage.message.id);
         if (self.isOnNewEmail) {
             check callOnNewEmail(self.httpService, message);
         }
@@ -142,7 +142,7 @@ class Dispatcher {
 
     function dispatchNewThread(gmail:HistoryEvent newMessage) returns @tainted error? {
         if(newMessage.message.id == newMessage.message.threadId) {               
-            gmail:MailThread thread = check self.gmailClient->readThread(ME, <@untainted>newMessage.message.threadId);
+            gmail:MailThread thread = check self.gmailClient->readThread(<@untainted>newMessage.message.threadId);
             check callOnNewThread(self.httpService, thread);
         }
     }
@@ -152,7 +152,7 @@ class Dispatcher {
         if (addedlabel?.labelIds is string []) {
             changedLabeldMsg.changedLabelId = <string []>addedlabel?.labelIds;
         }
-        gmail:Message message = check self.gmailClient->readMessage(ME, <@untainted>addedlabel.message.id);
+        gmail:Message message = check self.gmailClient->readMessage(<@untainted>addedlabel.message.id);
         changedLabeldMsg.message = message;
         check callOnNewLabeledEmail(self.httpService, changedLabeldMsg);
     }
@@ -162,7 +162,7 @@ class Dispatcher {
             foreach var label in <string[]>addedlabel?.labelIds {
                 match label{
                     STARRED =>{
-                        gmail:Message message = check self.gmailClient->readMessage(ME, <@untainted>addedlabel.message.id);
+                        gmail:Message message = check self.gmailClient->readMessage(<@untainted>addedlabel.message.id);
                         check callOnNewStarredEmail(self.httpService, message);
                     }
                 }
@@ -175,7 +175,7 @@ class Dispatcher {
         if (removedLabel?.labelIds is string[]) {
             changedLabeldMsg.changedLabelId = <string[]>removedLabel?.labelIds;
         }
-        gmail:Message message = check self.gmailClient->readMessage(ME, <@untainted>removedLabel.message.id);
+        gmail:Message message = check self.gmailClient->readMessage(<@untainted>removedLabel.message.id);
         changedLabeldMsg.message = message;
         check callOnLabelRemovedEmail(self.httpService, changedLabeldMsg);
     }
@@ -185,7 +185,7 @@ class Dispatcher {
             foreach var label in <string[]>removedLabel?.labelIds {
                 match label{
                     STARRED =>{
-                        gmail:Message message = check self.gmailClient->readMessage(ME, <@untainted>removedLabel.message.id);
+                        gmail:Message message = check self.gmailClient->readMessage(<@untainted>removedLabel.message.id);
                         check callOnStarRemovedEmail(self.httpService, message);
                     }
                 }

--- a/gmail/modules/listener/http_service.bal
+++ b/gmail/modules/listener/http_service.bal
@@ -22,7 +22,6 @@ service class HttpService {
 
     private gmail:Client gmailClient;
     public  string startHistoryId = "";
-    private string userId = ME;
     private Dispatcher dispatcher;
 
     public isolated function init(SimpleHttpService|HttpService httpService, gmail:Client gmailClient, 
@@ -34,7 +33,7 @@ service class HttpService {
 
     resource function post mailboxChanges(http:Caller caller, http:Request request) returns @tainted error? {
         check caller->respond(http:STATUS_OK);
-        var  mailboxHistoryPage =  self.gmailClient->listHistory(<@untainted>self.userId, self.startHistoryId);
+        var  mailboxHistoryPage =  self.gmailClient->listHistory(self.startHistoryId);
         
         if (mailboxHistoryPage is gmail:MailboxHistoryPage) {
             self.startHistoryId = mailboxHistoryPage.historyId;

--- a/gmail/tests/main_test.bal
+++ b/gmail/tests/main_test.bal
@@ -115,7 +115,7 @@ function testSendHTMLMessage() {
     string messageId = "";
     string threadId = "";
     if (sendMessageResponse is error) {
-        test:assertFail(msg = sendMessageResponse.message());
+        test:assertFail(msg = sendMessageResponse.toString());
     } else {
         messageId = sendMessageResponse.id;
         threadId = sendMessageResponse.threadId;

--- a/gmail/tests/main_test.bal
+++ b/gmail/tests/main_test.bal
@@ -79,7 +79,7 @@ function testSendTextMessage() {
     };
     log:printInfo("testSendTextMessage");
     //----Send the mail----
-    var sendMessageResponse = gmailClient->sendMessage(testUserId, messageRequest);
+    var sendMessageResponse = gmailClient->sendMessage(messageRequest,userId = testUserId);
     if (sendMessageResponse is Message) {
         sentTextMessageId = <@untainted>sendMessageResponse.id;
         sentTextMessageThreadId = <@untainted>sendMessageResponse.threadId;
@@ -111,7 +111,7 @@ function testSendHTMLMessage() {
     messageRequest.attachmentPaths = attachments;
     log:printInfo("testSendHTMLMessage");
     //----Send the mail----
-    var sendMessageResponse = gmailClient->sendMessage(testUserId, messageRequest);
+    var sendMessageResponse = gmailClient->sendMessage(messageRequest, userId = testUserId);
     string messageId = "";
     string threadId = "";
     if (sendMessageResponse is error) {
@@ -131,13 +131,13 @@ function testSendHTMLMessage() {
 function testModifyHTMLMessage() {
     //Modify labels of the message with message id which was sent in testSendHTMLMessage
     log:printInfo("testModifyHTMLMessage");
-    var response = gmailClient->modifyMessage(testUserId, sentHtmlMessageId, ["INBOX"], []);
+    var response = gmailClient->modifyMessage(sentHtmlMessageId, ["INBOX"], []);
     if (response is Message) {
         test:assertTrue(response.id == sentHtmlMessageId, msg = "Modify HTML message by adding new label failed");
     } else {
         test:assertFail(msg = response.message());
     }
-    response = gmailClient->modifyMessage(testUserId, sentHtmlMessageId, [], ["INBOX"]);
+    response = gmailClient->modifyMessage(sentHtmlMessageId, [], ["INBOX"]);
     if (response is Message) {
         test:assertTrue(response.id == sentHtmlMessageId,
         msg = "Modify HTML message by removing existing label failed");
@@ -153,7 +153,7 @@ function testListMessages() {
     //List All Messages with Label INBOX without including Spam and Trash
     log:printInfo("testListAllMessages");
     MsgSearchFilter searchFilter = {includeSpamTrash: false, labelIds: ["INBOX"]};
-    var msgList = gmailClient->listMessages("me", filter = searchFilter);
+    var msgList = gmailClient->listMessages(filter = searchFilter, userId = testUserId);
     if msgList is error {
         test:assertFail(msg = msgList.message());
     }
@@ -166,7 +166,7 @@ function testListMessages() {
 function testReadTextMessage() {
     //Read mail with message id which was sent in testSendSimpleMessage
     log:printInfo("testReadTextMessage");
-    var response = gmailClient->readMessage(testUserId, sentTextMessageId);
+    var response = gmailClient->readMessage(sentTextMessageId);
     if (response is Message) {
         testHistoryId = response?.historyId is string ? <@untainted>(<string>response?.historyId) : testHistoryId;
         test:assertEquals(response.id, sentTextMessageId, msg = "Read text mail failed");
@@ -182,7 +182,7 @@ function testReadTextMessage() {
 function testReadHTMLMessageWithAttachment() {
     //Read mail with message id which sent in testSendWithAttachment
     log:printInfo("testReadMessageWithAttachment");
-    var response = gmailClient->readMessage(testUserId, sentHtmlMessageId);
+    var response = gmailClient->readMessage(sentHtmlMessageId);
     if (response is Message) {
         if (response?.msgAttachments is MessageBodyPart[]) {
             MessageBodyPart[] msgAttachments = <MessageBodyPart[]>response?.msgAttachments;
@@ -201,7 +201,7 @@ function testReadHTMLMessageWithAttachment() {
 }
 function testgetAttachment() {
     log:printInfo("testgetAttachment");
-    var response = gmailClient->getAttachment(testUserId, sentHtmlMessageId, readAttachmentFileId);
+    var response = gmailClient->getAttachment(sentHtmlMessageId, readAttachmentFileId);
     if (response is MessageBodyPart) {
         if (response?.data is string) {
             test:assertTrue(<string>response?.data !==EMPTY_STRING, msg = "Get Attachment failed");
@@ -217,7 +217,7 @@ function testgetAttachment() {
 }
 function testTrashMessage() {
     log:printInfo("testTrashMessage");
-    var trash = gmailClient->trashMessage(testUserId, sentHtmlMessageId);
+    var trash = gmailClient->trashMessage(sentHtmlMessageId);
     if (trash is error) {
         test:assertFail(msg = trash.message());
     } else {
@@ -231,7 +231,7 @@ function testTrashMessage() {
 }
 function testUntrashMessage() {
     log:printInfo("testUntrashMessage");
-    var untrash = gmailClient->untrashMessage(testUserId, sentHtmlMessageId);
+    var untrash = gmailClient->untrashMessage(sentHtmlMessageId);
     if (untrash is error) {
         test:assertFail(msg = untrash.message());
     } else {
@@ -245,7 +245,7 @@ function testUntrashMessage() {
 }
 function testDeleteMessage() {
     log:printInfo("testDeleteMessage");
-    var delete = gmailClient->deleteMessage(testUserId, sentHtmlMessageId);
+    var delete = gmailClient->deleteMessage(sentHtmlMessageId);
     if (delete is error) {
         test:assertFail(msg = delete.toString());
     }
@@ -256,7 +256,7 @@ function testDeleteMessage() {
 }
 function testListThreads() {
     log:printInfo("testListThreads");
-    var threadList = gmailClient->listThreads(testUserId, filter = {includeSpamTrash: false, labelIds: ["INBOX"]});
+    var threadList = gmailClient->listThreads(filter = {includeSpamTrash: false, labelIds: ["INBOX"]});
     if (threadList is error) {
         test:assertFail(msg = threadList.message());
     }
@@ -268,7 +268,7 @@ function testListThreads() {
 }
 function testReadThread() {
     log:printInfo("testReadThread");
-    var thread = gmailClient->readThread(testUserId, sentTextMessageThreadId, format = FORMAT_METADATA,
+    var thread = gmailClient->readThread(sentTextMessageThreadId, format = FORMAT_METADATA,
         metadataHeaders = ["Subject"]);
     if (thread is MailThread) {
         test:assertEquals(thread.id, sentTextMessageThreadId, msg = "Read thread failed");
@@ -284,13 +284,13 @@ function testReadThread() {
 function testModifyThread() {
     //Modify labels of the thread with thread id which was sent in testSendTextMessage
     log:printInfo("testModifyThread");
-    var response = gmailClient->modifyThread(testUserId, sentTextMessageThreadId, ["INBOX"], []);
+    var response = gmailClient->modifyThread(sentTextMessageThreadId, ["INBOX"], []);
     if (response is MailThread) {
         test:assertTrue(response.id == sentTextMessageThreadId, msg = "Modify thread by adding new label failed");
     } else {
         test:assertFail(msg = response.message());
     }
-    response = gmailClient->modifyThread(testUserId, sentTextMessageThreadId, [], ["INBOX"]);
+    response = gmailClient->modifyThread(sentTextMessageThreadId, [], ["INBOX"]);
     if (response is MailThread) {
         test:assertTrue(response.id == sentTextMessageThreadId,
             msg = "Modify thread by removing existing label failed");
@@ -305,7 +305,7 @@ function testModifyThread() {
 }
 function testTrashThread() {
     log:printInfo("testTrashThread");
-    var trash = gmailClient->trashThread(testUserId, sentTextMessageThreadId);
+    var trash = gmailClient->trashThread(sentTextMessageThreadId);
     if (trash is error) {
         test:assertFail(msg = trash.message());
     } else {
@@ -319,7 +319,7 @@ function testTrashThread() {
 }
 function testUnTrashThread() {
     log:printInfo("testUnTrashThread");
-    var untrash = gmailClient->untrashThread(testUserId, sentTextMessageThreadId);
+    var untrash = gmailClient->untrashThread(sentTextMessageThreadId);
     if (untrash is error) {
         test:assertFail(msg = untrash.message());
     } else {
@@ -334,7 +334,7 @@ function testUnTrashThread() {
 }
 function testDeleteThread() {
     log:printInfo("testDeleteThread");
-    var delete = gmailClient->deleteThread(testUserId, sentTextMessageThreadId);
+    var delete = gmailClient->deleteThread(sentTextMessageThreadId);
     if (delete is error) {
         test:assertFail(msg = delete.toString());
     }
@@ -359,7 +359,7 @@ function testgetUserProfile() {
 }
 function testGetLabel() {
     log:printInfo("testgetLabel");
-    var response = gmailClient->getLabel(testUserId, createdLabelId);
+    var response = gmailClient->getLabel(createdLabelId);
     if (response is Label) {
         test:assertTrue(response.id !== EMPTY_STRING, msg = "Get Label failed");
     } else {
@@ -372,7 +372,7 @@ function testGetLabel() {
 }
 function testCreateLabel() {
     log:printInfo("testCreateLabel");
-    var createLabelResponse = gmailClient->createLabel(testUserId, "Test", "labelShow", "show");
+    var createLabelResponse = gmailClient->createLabel("Test", "labelShow", "show");
     if (createLabelResponse is Label) {
         createdLabelId = <@untainted>createLabelResponse.id;
         test:assertTrue(createdLabelId != "null", msg = "Create Label failed");
@@ -398,7 +398,7 @@ function testListLabels() {
 }
 function testDeleteLabel() {
     log:printInfo("testDeleteLabel");
-    var deleteLabelResponse = gmailClient->deleteLabel(testUserId, createdLabelId);
+    var deleteLabelResponse = gmailClient->deleteLabel(createdLabelId);
     if (deleteLabelResponse is error) {
         test:assertFail(msg = deleteLabelResponse.toString());
     }
@@ -413,7 +413,7 @@ function testUpdateLabel() {
     string updateName = "updateTest";
     string updateBgColor = "#16a766";
     string updateTxtColor = "#000000";
-    var updateLabelResponse = gmailClient->updateLabel(testUserId, createdLabelId, name = updateName,
+    var updateLabelResponse = gmailClient->updateLabel(createdLabelId, name = updateName,
     backgroundColor = updateBgColor, textColor = updateTxtColor);
     if (updateLabelResponse is error) {
         test:assertFail(msg = updateLabelResponse.message());
@@ -431,7 +431,7 @@ function testUpdateLabel() {
 function testListHistory() {
     log:printInfo("testListTheHistory");
     string[] historyTypes = ["labelAdded", "labelRemoved", "messageAdded", "messageDeleted"];
-    var listHistoryResponse = gmailClient->listHistory(testUserId, testHistoryId, historyTypes = historyTypes);
+    var listHistoryResponse = gmailClient->listHistory(testHistoryId, historyTypes = historyTypes);
     if (listHistoryResponse is error) {
         test:assertFail(msg = listHistoryResponse.message());
     } else {
@@ -449,7 +449,7 @@ function testListDrafts() {
     //List maximum of ten results for Drafts without including Spam and Trash
     log:printInfo("testListDrafts");
     DraftSearchFilter searchFilter = {includeSpamTrash: false, maxResults: 10};
-    var msgList = gmailClient->listDrafts("me", filter = searchFilter);
+    var msgList = gmailClient->listDrafts(filter = searchFilter);
     if (msgList is error) {
         test:assertFail(msg = msgList.message());
     }
@@ -464,12 +464,13 @@ function testCreateDraft() {
     string messageBody = "Draft Text Message Body";
     MessageRequest messageRequest = {
         recipient : testRecipient,
+        subject : "Create Draft Subject",
         sender : testSender,
         cc : testCc,
         messageBody : messageBody,
         contentType : TEXT_PLAIN
     };
-    var draftResponse = gmailClient->createDraft(testUserId, messageRequest, threadId = sentTextMessageThreadId);
+    var draftResponse = gmailClient->createDraft(messageRequest, threadId = sentTextMessageThreadId);
     if (draftResponse is string) {
         test:assertTrue(draftResponse != "null", msg = "Create Draft failed");
         createdDraftId = <@untainted>draftResponse;
@@ -494,7 +495,7 @@ function testUpdateDraft() {
     };    
     AttachmentPath[] attachments = [{attachmentPath: testAttachmentPath, mimeType: attachmentContentType}];
     messageRequest.attachmentPaths = attachments;
-    var draftResponse = gmailClient->updateDraft(testUserId, createdDraftId, messageRequest);
+    var draftResponse = gmailClient->updateDraft(createdDraftId, messageRequest);
     if (draftResponse is string) {
         test:assertTrue(draftResponse == createdDraftId, msg = "Update Draft failed");
     } else {
@@ -508,7 +509,7 @@ function testUpdateDraft() {
 }
 function testReadDraft() {
     log:printInfo("testReadDraft");
-    var draftResponse = gmailClient->readDraft(testUserId, createdDraftId);
+    var draftResponse = gmailClient->readDraft(createdDraftId);
     if (draftResponse is Draft) {
         test:assertTrue(draftResponse.id == createdDraftId, msg = "Read Draft failed");
     } else {
@@ -522,7 +523,7 @@ function testReadDraft() {
 }
 function testSendDraft() {
     log:printInfo("testSendDraft");
-    var sendDraftResponse = gmailClient->sendDraft(testUserId, createdDraftId);
+    var sendDraftResponse = gmailClient->sendDraft(createdDraftId);
     if (sendDraftResponse is error) {
         test:assertFail(msg = sendDraftResponse.message());
     } else {
@@ -544,7 +545,7 @@ function testDeleteDraft() {
         messageBody : "Draft Text Message Body To Delete",
         contentType : TEXT_PLAIN
     };    
-    var draftResponse = gmailClient->createDraft(testUserId, messageRequest);
+    var draftResponse = gmailClient->createDraft(messageRequest);
     string draftIdToDelete = "";
     if (draftResponse is string) {
         test:assertTrue(draftResponse != "null", msg = "Create Draft failed");
@@ -553,7 +554,7 @@ function testDeleteDraft() {
         test:assertFail(msg = draftResponse.message());
     }
     //Delete the created draft
-    var deleteResponse = gmailClient->deleteDraft(testUserId, draftIdToDelete);
+    var deleteResponse = gmailClient->deleteDraft(draftIdToDelete);
     if (deleteResponse is error) {
         test:assertFail(msg = deleteResponse.toString());
     }

--- a/gmail/types.bal
+++ b/gmail/types.bal
@@ -54,9 +54,11 @@ public type MailThread record {
 #
 # + recipient - The recipient of the mail
 # + subject - The subject of the mail
-# + contentType - The content type of the mail, whether it is text/plain or text/html. Only pass one of the
-#                        constant values defined in the module; `TEXT_PLAIN` or `TEXT_HTML`
 # + messageBody - The message body of the mail. Can be either plain text or html text.
+# + contentType - The content type of the mail, whether it is text/plain or text/html. Only pass one of the
+#                 constant values defined in the module; `TEXT_PLAIN` or `TEXT_HTML`. If the message contains some rich
+#                 content (Eg: inline image, table etc), then it should be text/html (`TEXT_HTML`) other wise it will
+#                 be text/plain (`TEXT_PLAIN`).
 # + cc - The cc recipient of the mail. Optional.
 # + bcc - The bcc recipient of the mail. Optional.
 # + sender - The sender of the mail. Optional
@@ -69,10 +71,10 @@ public type MessageRequest record {
     string recipient;
     @display {label: "Subject"}
     string subject;
-    @display {label: "Content Type"}
-    string contentType;
     @display {label: "Message Body"}
     string messageBody;
+    @display {label: "Content Type"}
+    string contentType?;
     @display {label: "Cc"}
     string cc?;
     @display {label: "Bcc"}

--- a/gmail/types.bal
+++ b/gmail/types.bal
@@ -54,12 +54,12 @@ public type MailThread record {
 #
 # + recipient - The recipient of the mail
 # + subject - The subject of the mail
-# + messageBody - The message body of the mail. Can be either plain text or html text.
 # + contentType - The content type of the mail, whether it is text/plain or text/html. Only pass one of the
 #                        constant values defined in the module; `TEXT_PLAIN` or `TEXT_HTML`
-# + sender - The sender of the mail
+# + messageBody - The message body of the mail. Can be either plain text or html text.
 # + cc - The cc recipient of the mail. Optional.
 # + bcc - The bcc recipient of the mail. Optional.
+# + sender - The sender of the mail. Optional
 # + inlineImagePaths - The InlineImagePath array consisting the inline image file paths and mime types. Optional.
 #                            Note that inline images can only be send for `TEXT_HTML` messages.
 # + attachmentPaths - The AttachmentPath array consisting the attachment file paths and mime types. Optional.
@@ -68,17 +68,17 @@ public type MessageRequest record {
     @display {label: "Recipient"}
     string recipient;
     @display {label: "Subject"}
-    string subject?;
-    @display {label: "Message Body"}
-    string messageBody;
+    string subject;
     @display {label: "Content Type"}
     string contentType;
-    @display {label: "Sender"}
-    string sender;
+    @display {label: "Message Body"}
+    string messageBody;
     @display {label: "Cc"}
     string cc?;
     @display {label: "Bcc"}
     string bcc?;
+    @display {label: "Sender"}
+    string sender?;
     @display {label: "Inline Image Paths"}
     InlineImagePath[] inlineImagePaths?;
     @display {label: "Attachment Paths"}

--- a/gmail/utils.bal
+++ b/gmail/utils.bal
@@ -356,12 +356,6 @@ isolated function getValueForMapKey(map<string> targetMap, string key) returns s
 # + msgRequest - MessageRequest to create the message
 # + return - If successful, returns the encoded raw string. Else returns error.
 function createEncodedRawMessage(MessageRequest msgRequest) returns string|error {
-    //The content type should be either TEXT_PLAIN or TEXT_HTML. If not returns an error.
-    if (msgRequest.contentType != TEXT_PLAIN && msgRequest.contentType != TEXT_HTML) {
-        error err = error(GMAIL_ERROR_CODE, message = "Does not support the given content type: "
-            + msgRequest.contentType + " for the message with subject: " + msgRequest.subject);
-        return err;
-    }
     //Adding inline images to messages of TEXT_PLAIN content type is not supported.
     InlineImagePath[] inlineImagePaths = [];
     AttachmentPath[] attachmentPaths = [];
@@ -371,7 +365,7 @@ function createEncodedRawMessage(MessageRequest msgRequest) returns string|error
     if (msgRequest?.attachmentPaths is AttachmentPath[]) {
         attachmentPaths = <AttachmentPath[]>msgRequest?.attachmentPaths;
     }    
-    if (msgRequest.contentType == TEXT_PLAIN && (inlineImagePaths.length() != 0)) {
+    if (msgRequest?.contentType == TEXT_PLAIN && (inlineImagePaths.length() != 0)) {
         error err = error(GMAIL_ERROR_CODE, message =
                     "Does not support adding inline images to text/plain body of the message with subject: "
                     + msgRequest.subject);
@@ -413,7 +407,7 @@ function createEncodedRawMessage(MessageRequest msgRequest) returns string|error
         + BOUNDARY + EQUAL_SYMBOL + APOSTROPHE_SYMBOL + BOUNDARY_STRING_2 + APOSTROPHE_SYMBOL + NEW_LINE;
 
     //Set the body part : text/plain
-    if (msgRequest.contentType == TEXT_PLAIN) {
+    if (msgRequest?.contentType == TEXT_PLAIN) {
         concatRequest += NEW_LINE + DASH_SYMBOL + DASH_SYMBOL + BOUNDARY_STRING_2 + NEW_LINE;
         concatRequest += CONTENT_TYPE + COLON_SYMBOL + TEXT_PLAIN + SEMICOLON_SYMBOL + CHARSET + EQUAL_SYMBOL
             + APOSTROPHE_SYMBOL + UTF_8 + APOSTROPHE_SYMBOL + NEW_LINE;
@@ -421,7 +415,7 @@ function createEncodedRawMessage(MessageRequest msgRequest) returns string|error
     }
 
     //Set the body part : text/html
-    if (msgRequest.contentType == TEXT_HTML) {
+    if (msgRequest?.contentType == TEXT_HTML) {
         concatRequest += NEW_LINE + DASH_SYMBOL + DASH_SYMBOL + BOUNDARY_STRING_2 + NEW_LINE;
         concatRequest += CONTENT_TYPE + COLON_SYMBOL + TEXT_HTML + SEMICOLON_SYMBOL + CHARSET + EQUAL_SYMBOL
             + APOSTROPHE_SYMBOL + UTF_8 + APOSTROPHE_SYMBOL + NEW_LINE;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.googleapis.gmail
-version=0.99.8
+version=0.99.9
 ballerinaLangVersion=2.0.0-alpha8-20210423-135000-530658ec

--- a/samples/drafts/create_draft.bal
+++ b/samples/drafts/create_draft.bal
@@ -32,8 +32,6 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Create draft");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     // The ID of the thread the draft should sent to. this is optional.
     string sentMessageThreadId = "<THREAD_ID>";
 
@@ -46,7 +44,7 @@ public function main(string... args) {
         contentType : gmail:TEXT_PLAIN
     };
 
-    string|error draftResponse = gmailClient->createDraft(userId, messageRequest, threadId = sentMessageThreadId);
+    string|error draftResponse = gmailClient->createDraft(messageRequest, threadId = sentMessageThreadId);
     
     if (draftResponse is string) {
         log:printInfo("Successfully created draft: ", draftId = draftResponse);

--- a/samples/drafts/delete_draft.bal
+++ b/samples/drafts/delete_draft.bal
@@ -32,13 +32,11 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Delete a draft");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     
     // The ID of the existing draft we want to delete.
     string createdDraftId = "<DRAFT_ID>"; 
 
-    error? deleteResponse = gmailClient->deleteDraft(userId, createdDraftId);
+    error? deleteResponse = gmailClient->deleteDraft(createdDraftId);
 
     if (deleteResponse is error) {
         log:printError("Failed to delete the draft");

--- a/samples/drafts/list_drafts.bal
+++ b/samples/drafts/list_drafts.bal
@@ -37,7 +37,7 @@ public function main(string... args) {
 
     gmail:DraftSearchFilter searchFilter = {includeSpamTrash: false, maxResults: 10};
     
-    gmail:DraftListPage|error msgList = gmailClient->listDrafts(userId, filter = searchFilter);
+    gmail:DraftListPage|error msgList = gmailClient->listDrafts(filter = searchFilter, userId = userId);
     if (msgList is gmail:DraftListPage) {
         error? e = msgList.drafts.forEach(function (gmail:DraftList draft) {
             log:printInfo(draft.toString());

--- a/samples/drafts/read_draft.bal
+++ b/samples/drafts/read_draft.bal
@@ -32,13 +32,11 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Read a draft");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     
     // The ID of the existing draft we want to read.
     string createdDraftId = "<DRAFT_ID>"; 
 
-    gmail:Draft|error draftReadResponse = gmailClient->readDraft(userId, createdDraftId);
+    gmail:Draft|error draftReadResponse = gmailClient->readDraft(createdDraftId);
     if (draftReadResponse is gmail:Draft) {
         log:printInfo("Successfully read the draft: ", status = draftReadResponse.id == createdDraftId);
     } else {

--- a/samples/drafts/send_draft.bal
+++ b/samples/drafts/send_draft.bal
@@ -32,13 +32,11 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Send draft");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     
     // The ID of the existing draft we want to send.
     string createdDraftId = "<DRAFT_ID>"; 
 
-    gmail:Message |error sendDraftResponse = gmailClient->sendDraft(userId, createdDraftId);
+    gmail:Message |error sendDraftResponse = gmailClient->sendDraft(createdDraftId);
     
     if (sendDraftResponse is gmail:Message) {
         log:printInfo("Sent the draft successfully: ",

--- a/samples/drafts/update_draft.bal
+++ b/samples/drafts/update_draft.bal
@@ -32,8 +32,6 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Update draft"); // New update will be to update the darft subject, body and attchments.
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // The ID of the draft to update. This will be returned when a draft is created. 
     string createdDraftId = "<DRAFT_ID>";
@@ -53,7 +51,7 @@ public function main(string... args) {
     gmail:AttachmentPath[] attachments = [{attachmentPath: testAttachmentPath, mimeType: attachmentContentType}];
     newMessageRequest.attachmentPaths = attachments;
 
-    string|error draftUpdateResponse = gmailClient->updateDraft(userId, createdDraftId, newMessageRequest);
+    string|error draftUpdateResponse = gmailClient->updateDraft(createdDraftId, newMessageRequest);
     if (draftUpdateResponse is string) {
         log:printInfo("Successfully updated the draft: ", result = draftUpdateResponse);
     } else {

--- a/samples/labels/create_label.bal
+++ b/samples/labels/create_label.bal
@@ -32,16 +32,13 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Create label");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     string displayName = "Test";
     // The visibility of the label in the label list in the Gmail web interface.
     string labelVisibility = "labelShow";
     // The visibility of messages with this label in the message list in the Gmail web interface.
     string messageListVisibility = "show";
 
-    string|error createLabelResponse = gmailClient->createLabel(userId, displayName, labelVisibility, 
-        messageListVisibility);
+    string|error createLabelResponse = gmailClient->createLabel(displayName, labelVisibility, messageListVisibility);
     
     if (createLabelResponse is string) {
         log:printInfo("Successfully created label: ", labelId = createLabelResponse);

--- a/samples/labels/delete_label.bal
+++ b/samples/labels/delete_label.bal
@@ -32,13 +32,11 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Delete label");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     
     // The ID of an already created label that we want to delete
     string createdLabelId = "<LABEL_ID>";
 
-    error? deleteLabelResponse = gmailClient->deleteLabel(userId, createdLabelId);
+    error? deleteLabelResponse = gmailClient->deleteLabel(createdLabelId);
      
     if (deleteLabelResponse is error) {
         log:printInfo("Failed to delete the message");

--- a/samples/labels/update_label.bal
+++ b/samples/labels/update_label.bal
@@ -32,8 +32,6 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Update label");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     
     // The ID of an already created label that we want to update
     string createdLabelId = "Label_20";
@@ -42,7 +40,7 @@ public function main(string... args) {
     string updateBgColor = "#16a766";
     string updateTxtColor = "#000000";
 
-    gmail:Label|error updateLabelResponse = gmailClient->updateLabel(userId, createdLabelId, name = updateName,
+    gmail:Label|error updateLabelResponse = gmailClient->updateLabel(createdLabelId, name = updateName,
         backgroundColor = updateBgColor, textColor = updateTxtColor);
 
     if (updateLabelResponse is gmail:Label) {

--- a/samples/list_history.bal
+++ b/samples/list_history.bal
@@ -32,25 +32,24 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("List the profile history");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
+    
     // TO get the history ID we have to get the history ID referring to message response.
     string sentMessageId = "<MESSAGE_ID>";
 
     // This operation returns history records after the specified `startHistoryId`. The supplied startHistoryId should be 
     // obtained from the historyId of a message, thread, or previous list response.
     string startHistoryId;
-    var response = gmailClient->readMessage(userId, sentMessageId);
+    var response = gmailClient->readMessage(sentMessageId);
 
     if (response is gmail:Message) {
 
-        startHistoryId = response.historyId;
+        startHistoryId = response?.historyId is string ? <string>response?.historyId : "" ;
         
         // History types to be returned by the function
         string[] historyTypes = ["labelAdded", "labelRemoved", "messageAdded", "messageDeleted"];
 
-        gmail:MailboxHistoryPage|error listHistoryResponse = gmailClient->listHistory(userId, startHistoryId, 
-            historyTypes = historyTypes);
+        gmail:MailboxHistoryPage|error listHistoryResponse = gmailClient->listHistory(startHistoryId, 
+                                                                                      historyTypes = historyTypes);
 
         if (listHistoryResponse is gmail:MailboxHistoryPage) {
             if (listHistoryResponse?.history is gmail:History[]) {

--- a/samples/messages/delete_message.bal
+++ b/samples/messages/delete_message.bal
@@ -34,13 +34,11 @@ public function main(string... args) {
     // This method immediately and permanently deletes the specified message
     log:printInfo("Delete a message");
 
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     
     // Id of the message to delete. This can be obtained from the response of create message.
     string sentMessageId = "<MESSAGE_ID>"; 
 
-    error? delete = gmailClient->deleteMessage(userId, sentMessageId);
+    error? delete = gmailClient->deleteMessage(sentMessageId);
     
     if (delete is error) {
         log:printError("Failed to delete the message");

--- a/samples/messages/get_attachment.bal
+++ b/samples/messages/get_attachment.bal
@@ -32,8 +32,6 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("Get an attachment in a sent message");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the message where the attachment belongs to.
     string sentHtmlMessageId = "<MESSAGE_ID>"; 
@@ -42,7 +40,7 @@ public function main(string... args) {
     string readAttachmentFileId;
 
     // To read the attachment you should first obtain the attachment file ID 
-    gmail:Message|error readResponse = gmailClient->readMessage(userId, sentHtmlMessageId);
+    gmail:Message|error readResponse = gmailClient->readMessage(sentHtmlMessageId);
     
     if (readResponse is gmail:Message) {
         log:printInfo("Meesage information retrieved");
@@ -50,7 +48,7 @@ public function main(string... args) {
             gmail:MessageBodyPart[] msgAttachments = <gmail:MessageBodyPart[]>readResponse?.msgAttachments;
             readAttachmentFileId = msgAttachments[0]?.fileId is string ? <@untainted>(<string>msgAttachments[0]?.fileId)
                                     : readAttachmentFileId;
-            gmail:MessageBodyPart|error response = gmailClient->getAttachment(userId, sentHtmlMessageId, 
+            gmail:MessageBodyPart|error response = gmailClient->getAttachment(sentHtmlMessageId, 
                 readAttachmentFileId);
             if (response is gmail:MessageBodyPart) {
                 log:printInfo("Attachment " + response.toString());

--- a/samples/messages/list_messages.bal
+++ b/samples/messages/list_messages.bal
@@ -32,15 +32,13 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("List all messages");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
     string[] labelsToMatch = ["INBOX"];
 
     // To exclude messages from spam and trash make set includeSpamTrash to false. Only return messages with labels that 
     // match all of the specified label ID "INBOX"
     gmail:MsgSearchFilter searchFilter = {includeSpamTrash: false, labelIds: labelsToMatch};
     
-    gmail:MessageListPage|error msgList = gmailClient->listMessages(userId, filter = searchFilter);
+    gmail:MessageListPage|error msgList = gmailClient->listMessages(filter = searchFilter);
 
     if (msgList is gmail:MessageListPage) {
         error? e = msgList.messages.forEach(function (gmail:Message message) {

--- a/samples/messages/modify_message.bal
+++ b/samples/messages/modify_message.bal
@@ -32,8 +32,6 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("Modify labels of a HTML message");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the message to modify.
     string sentMessageId = "<MESSAGE_ID>"; 
@@ -42,7 +40,7 @@ public function main(string... args) {
     string[] labelsToRemove = ["INBOX"];
 
     log:printInfo("Add Labels");
-    gmail:Message|error response = gmailClient->modifyMessage(userId, sentMessageId, labelsToAdd, []);
+    gmail:Message|error response = gmailClient->modifyMessage(sentMessageId, labelsToAdd, []);
 
     if (response is gmail:Message) {
         log:printInfo("Is lablel modified: ", status = response.id == sentMessageId);
@@ -51,7 +49,7 @@ public function main(string... args) {
     }
 
     log:printInfo("Remove Labels");
-    response = gmailClient->modifyMessage(userId, sentMessageId, [], labelsToRemove);
+    response = gmailClient->modifyMessage(sentMessageId, [], labelsToRemove);
     
     if (response is gmail:Message) {
         log:printInfo("Is lablel modified: ", ststus = response.id == sentMessageId);

--- a/samples/messages/read_message_with_attachments.bal
+++ b/samples/messages/read_message_with_attachments.bal
@@ -32,13 +32,11 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("Read a message with an attachment");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the message to read with an attachment.
     string sentMessageId = "<MESSAGE_ID>"; 
 
-    gmail:Message|error response = gmailClient->readMessage(userId, sentMessageId);
+    gmail:Message|error response = gmailClient->readMessage(sentMessageId);
     
     if (response is gmail:Message) {
        if (response?.msgAttachments is gmail:MessageBodyPart[] ) {

--- a/samples/messages/read_text_message.bal
+++ b/samples/messages/read_text_message.bal
@@ -32,13 +32,11 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("Read a message");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the message to read.
     string sentMessageId = "<MESSAGE_ID>"; 
     
-    gmail:Message|error response = gmailClient->readMessage(userId, sentMessageId);
+    gmail:Message|error response = gmailClient->readMessage(sentMessageId);
     
     if (response is gmail:Message) {
         log:printInfo("Is message details available: ", status = response.id == sentMessageId);

--- a/samples/messages/send_html_message.bal
+++ b/samples/messages/send_html_message.bal
@@ -32,8 +32,6 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Send a HTML message");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     string inlineImageName = "test_image.png";
     string htmlBody = "<h1> Email Test HTML Body </h1> <br/> <img src=\"cid:image-" + inlineImageName + "\">";
@@ -60,7 +58,7 @@ public function main(string... args) {
     gmail:AttachmentPath[] attachments = [{attachmentPath: testAttachmentPath, mimeType: attachmentContentType}];
     messageRequest.attachmentPaths = attachments;
 
-    gmail:Message|error sendMessageResponse = gmailClient->sendMessage(userId, messageRequest);
+    gmail:Message|error sendMessageResponse = gmailClient->sendMessage(messageRequest);
 
     if (sendMessageResponse is gmail:Message) {
         // If successful, print the message ID and thread ID.

--- a/samples/messages/send_text_message.bal
+++ b/samples/messages/send_text_message.bal
@@ -32,8 +32,6 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
     
     log:printInfo("Send the message");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     gmail:MessageRequest messageRequest = {
         recipient : os:getEnv("RECIPIENT"), // Recipient's email address
@@ -52,7 +50,7 @@ public function main(string... args) {
     gmail:AttachmentPath[] attachments = [{attachmentPath: testAttachmentPath, mimeType: attachmentContentType}];
     messageRequest.attachmentPaths = attachments;
 
-    gmail:Message|error sendMessageResponse = checkpanic gmailClient->sendMessage(userId, messageRequest);
+    gmail:Message|error sendMessageResponse = checkpanic gmailClient->sendMessage(messageRequest);
     
     if (sendMessageResponse is gmail:Message) {
         // If successful, print the message ID and thread ID.

--- a/samples/messages/trash_message.bal
+++ b/samples/messages/trash_message.bal
@@ -33,13 +33,11 @@ public function main(string... args) {
     
     // Moves the specified message to the trash.
     log:printInfo("Trash a message");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the message to trash.
     string sentMessageId = "<MESSAGE_ID>"; 
 
-    gmail:Message|error trash = gmailClient->trashMessage(userId, sentMessageId);
+    gmail:Message|error trash = gmailClient->trashMessage(sentMessageId);
 
     if (trash is gmail:Message) {
         log:printInfo("Successfully trashed the message");

--- a/samples/messages/untrash_message.bal
+++ b/samples/messages/untrash_message.bal
@@ -33,13 +33,11 @@ public function main(string... args) {
 
     // Removes the specified message from the trash.
     log:printInfo("Untrash a message");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the message to untrash.
     string sentMessageId = "<MESSAGE_ID>"; 
 
-    gmail:Message|error untrash = gmailClient->untrashMessage(userId, sentMessageId);
+    gmail:Message|error untrash = gmailClient->untrashMessage(sentMessageId);
 
     if (untrash is gmail:Message) {
         log:printInfo("Successfully un-trashed the message");

--- a/samples/threads/delete_thread.bal
+++ b/samples/threads/delete_thread.bal
@@ -32,13 +32,11 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("Delete thread");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the thread to delete.
     string sentMessageThreadId = "<THREAD_ID"; 
 
-    error? delete = gmailClient->deleteThread(userId, sentMessageThreadId);
+    error? delete = gmailClient->deleteThread(sentMessageThreadId);
  
     if (delete is error) {
         log:printError("Failed to delete the thread");

--- a/samples/threads/list_threads.bal
+++ b/samples/threads/list_threads.bal
@@ -32,11 +32,9 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("List threads");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // Make includeSpamTrash false to exclude threads from SPAM and TRASH in the results.
-    gmail:ThreadListPage|error threadList = gmailClient->listThreads(userId, filter = {includeSpamTrash: false, 
+    gmail:ThreadListPage|error threadList = gmailClient->listThreads(filter = {includeSpamTrash: false, 
         labelIds: ["INBOX"]});
         
     if (threadList is gmail:ThreadListPage) {  

--- a/samples/threads/modify_thread.bal
+++ b/samples/threads/modify_thread.bal
@@ -32,15 +32,12 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("Modify labels in a thread");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
-
     // ID of the thread to modify.
     string sentMessageThreadId = "<THREAD_ID";
 
     // Modify labels of the thread with thread id which was sent in testSendTextMessage
     log:printInfo("Add labels to a thread");
-    gmail:MailThread|error response = gmailClient->modifyThread(userId, sentMessageThreadId, ["INBOX"], []);
+    gmail:MailThread|error response = gmailClient->modifyThread(sentMessageThreadId, ["INBOX"], []);
 
     if (response is gmail:MailThread) {
         log:printInfo("Add labels to thread successfully: ", status = response.id == sentMessageThreadId);
@@ -49,7 +46,7 @@ public function main(string... args) {
     }
 
     log:printInfo("Remove labels from a thread");
-    response = gmailClient->modifyThread(userId, sentMessageThreadId, [], ["INBOX"]);
+    response = gmailClient->modifyThread(sentMessageThreadId, [], ["INBOX"]);
     
     if (response is gmail:MailThread) {
         log:printInfo("Removed labels from thread successfully: ", status = response.id == sentMessageThreadId);

--- a/samples/threads/read_one_thread.bal
+++ b/samples/threads/read_one_thread.bal
@@ -32,14 +32,12 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("Read one thread");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the thread to read.
     string sentMessageThreadId = "<THREAD_ID"; 
 
     // When given and format is METADATA, only include headers specified. Here, it will specify "Subject"
-    gmail:MailThread|error thread = gmailClient->readThread(userId, sentMessageThreadId, format = gmail:FORMAT_METADATA, 
+    gmail:MailThread|error thread = gmailClient->readThread(sentMessageThreadId, format = gmail:FORMAT_METADATA, 
         metadataHeaders = ["Subject"]);
         
     if (thread is gmail:MailThread) {

--- a/samples/threads/trash_untrash_thread.bal
+++ b/samples/threads/trash_untrash_thread.bal
@@ -32,14 +32,12 @@ gmail:Client gmailClient = new(gmailConfig);
 public function main(string... args) {
 
     log:printInfo("Trash and Untrash thread");
-    // The user's email address. The special value **me** can be used to indicate the authenticated user.
-    string userId = "me";
 
     // ID of the thread to trash or untrash.
     string sentMessageThreadId = "<THREAD_ID"; 
 
     log:printInfo("Trash thread");
-    gmail:MailThread|error trash = gmailClient->trashThread(userId, sentMessageThreadId);
+    gmail:MailThread|error trash = gmailClient->trashThread(sentMessageThreadId);
 
     if (trash is gmail:MailThread) {
         log:printInfo("Successfully trashed the thread");
@@ -48,7 +46,7 @@ public function main(string... args) {
     } 
 
     log:printInfo("Un-trash thread");
-    gmail:MailThread|error untrash = gmailClient->untrashThread(userId, sentMessageThreadId);
+    gmail:MailThread|error untrash = gmailClient->untrashThread(sentMessageThreadId);
 
     if (untrash is gmail:MailThread) {
         log:printInfo("Successfully un-trashed the thread");


### PR DESCRIPTION
## Purpose
> Current Gmail connector has userId as a required parameter for all remote methods. But for authenticated user , value `me` can be used instead of userId. Due to that  userId can be marked as an optional parameter. Same time, to send a message MessageRequest record parameter has the sender as required field. But It can be marked as optional. Field subject also need to be marked as required

## Goals

-  Mark userId as optional parameter
-  Mark sender as optional field
-  Mark subject as required parameter
-  Update samples and Documentation according to the above mentioned changes.
