### PR TITLE
Respond the caller at the end in listener

### DIFF
--- a/gmail/modules/listener/http_service.bal
+++ b/gmail/modules/listener/http_service.bal
@@ -36,7 +36,6 @@ service class HttpService {
     isolated resource function post mailboxChanges(http:Caller caller, http:Request request) returns @tainted error? {
         json ReqPayload = check request.getJsonPayload();
         string incomingSubscription = check ReqPayload.subscription;
-        check caller->respond(http:STATUS_OK);
 
         if (self.subscriptionResource === incomingSubscription) {
             var  mailboxHistoryPage =  self.gmailClient->listHistory(self.startHistoryId);
@@ -54,5 +53,6 @@ service class HttpService {
         } else {
             log:printWarn(WARN_UNKNOWN_PUSH_NOTIFICATION + incomingSubscription);
         }
+        check caller->respond(http:STATUS_OK);
     }
 }

--- a/samples/listener/trigger_on_new_email_heavy_processing.bal 
+++ b/samples/listener/trigger_on_new_email_heavy_processing.bal 
@@ -1,0 +1,46 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/googleapis.gmail as gmail;
+import ballerinax/googleapis.gmail.'listener as gmailListener;
+
+configurable string refreshToken = ?;
+configurable string clientId = ?;
+configurable string clientSecret = ?;
+configurable int port = ?;
+configurable string project = ?;
+configurable string pushEndpoint = ?;
+
+gmail:GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
+        refreshUrl: gmail:REFRESH_URL,
+        refreshToken: refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret
+        }
+};
+
+listener gmailListener:Listener gmailEventListener = new(port, gmailConfig,  project, pushEndpoint);
+
+service / on gmailEventListener {
+   remote function onNewEmail(gmail:Message message) returns error? {
+        _ = @strand { thread: "any" } start userLogic(message);
+   }   
+}
+
+function userLogic(gmail:Message message) returns error? {
+    // Write your logic here
+}


### PR DESCRIPTION
## Purpose
> The problem with our listener functions are, as soon as we receive the event, we respond with status 200 OK, and then we dispatch the event. At user function implementation if there was an error we throw it up. In this case, as we have already responded with 200 OK, http client cannot convert the error and respond again, because it cannot respond to the same message twice.

> Ideally we should respond with status 200 OK only after dispatching the event. At user function implementation if there was an error we throw it up & the http client will return status 500 error. If no any error occurred & the user logic is executed successfully we should respond with status 200 OK.

## Goals
> Return http response after user logic execution in listener
