### PR TITLE
Bump jar version to 0.99.12 same as bal package

### DIFF
--- a/gmail/Ballerina.toml
+++ b/gmail/Ballerina.toml
@@ -12,7 +12,7 @@ license = ["Apache-2.0"]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.99.11.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.99.12.jar"
 groupId = "org.ballerinalang.googleapis.gmail"
 artifactId = "java-wrapper"
-version = "0.99.11"
+version = "0.99.12"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.googleapis.gmail
-version=0.99.11
+version=0.99.12
 ballerinaLangVersion=2.0.0-beta.3


### PR DESCRIPTION
# Description
Bump java component version to 0.99.12 same as ballerina package version mentioned in Ballerina.toml
 
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 