### PR TITLE
Inform attachment size limit

### DIFF
--- a/gmail/endpoint.bal
+++ b/gmail/endpoint.bal
@@ -52,7 +52,8 @@ public isolated client class Client {
     # Creates the raw base 64 encoded string of the whole message and send it as an email from the user's
     # mailbox to its recipient.
     #
-    # + message - MessageRequest to send
+    # + message - MessageRequest to send. Note: Here if any attachments included in the message, those attachments need
+    #             to be less than 25MB.
     # + threadId - Optional. Required if message is expected to be send The ID of the thread the message belongs to.
     # (The Subject headers must match)
     # + userId - The user's email address. The special value **me** can be used to indicate the authenticated user.

--- a/gmail/types.bal
+++ b/gmail/types.bal
@@ -137,8 +137,10 @@ public type AttachmentPath record {
 # + mimeType - MIME type of the top level message part
 # + emailBodyInText - MIME Message Part with text/plain content type
 # + emailBodyInHTML - MIME Message Part with text/html content type
-# + emailInlineImages - MIME Message Parts with inline images with the image/* content type
-# + msgAttachments - MIME Message Parts of the message consisting the attachments
+# + emailInlineImages - MIME Message Parts with inline images with the image/* content type. Note: Here attachments 
+#                       need to be less than 25MB.
+# + msgAttachments - MIME Message Parts of the message consisting the attachments. Note: Here attachments need to be 
+#                    less than 25MB.
 @display {label: "Message"}
 public type Message record {
     @display {label: "Thread ID"}


### PR DESCRIPTION
# Description

It will update the API doc to inform the user regarding the attachment size when they sent a message with attachments. 

Fixes # https://github.com/ballerina-platform/ballerina-extended-library/issues/49

One line release note: 
- It's a documentation update. No need a new release. We can proceed in the next release. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
