### PR TITLE
Change daily run to run every Sunday

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -3,7 +3,7 @@ name: Daily build
 on:
   workflow_dispatch:
   schedule:
-    - cron: "30 2 * * *"
+    - cron: "30 2 * * SUN"
 
 jobs:
   call_workflow:


### PR DESCRIPTION
This job is frequently failing due to an internal server error from Gmail. The issue is not related to the connector.

Change the schedule from running daily to every Sunday.

## Purpose

Fixes:

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
