### PR TITLE
Fix invalid UTF-8 byte error when retrieving PDF attachments

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.8.0"
 org = "ballerinax"
 name = "googleapis.gmail"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Ballerina"]
 export = ["googleapis.gmail"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-googleapis.gmail"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.13.5"
+version = "2.13.8"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -350,7 +350,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "googleapis.gmail"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},

--- a/ballerina/data_mappings.bal
+++ b/ballerina/data_mappings.bal
@@ -27,7 +27,7 @@ isolated function convertOASMessageToMessage(oas:Message response) returns Messa
     do {
         string? rawMessage = response.raw;
         if rawMessage is string {
-            email.raw = check base64UrlDecode(rawMessage);
+            email.raw = check base64UrlDecodeToString(rawMessage);
         }
     } on fail error err {
         return error ValueEncodeError(string `Returned message raw field${err.message()}`, err.cause());
@@ -106,7 +106,12 @@ returns MessagePart|error {
         do {
             string? data = body.data;
             if data is string {
-                messagePart.data = check base64UrlDecode(data);
+                string|error textData = base64UrlDecodeToString(data);
+                if textData is string {
+                    messagePart.data = textData;
+                } else {
+                    messagePart.rawData = check base64UrlDecodeToBytes(data);
+                }
             }
         } on fail error err {
             check error ValueEncodeError(
@@ -270,7 +275,12 @@ isolated function convertOASMessagePartBodyToAttachment(oas:MessagePartBody body
     do {
         string? data = bodyPart.data;
         if data is string {
-            attachment.data = check base64UrlDecode(data);
+            string|error textData = base64UrlDecodeToString(data);
+            if textData is string {
+                attachment.data = textData;
+            } else {
+                attachment.rawData = check base64UrlDecodeToBytes(data);
+            }
         }
     } on fail error err {
         return error ValueEncodeError(

--- a/ballerina/tests/test_w_mock_server.bal
+++ b/ballerina/tests/test_w_mock_server.bal
@@ -123,6 +123,41 @@ function testUrlDecodeFailure() returns error? {
 @test:Config {
     groups: ["mock"]
 }
+isolated function testBase64UrlDecodeWithInvalidInput() {
+    byte[]|error result = base64UrlDecodeToBytes("@#$%");
+    test:assertTrue(result is error,
+            msg = "base64UrlDecodeToBytes should return an error for invalid base64url input");
+    if result is error {
+        test:assertEquals(result.message(), " is not a valid Base64 URL encoded value.",
+                msg = "base64UrlDecodeToBytes error message mismatch");
+    }
+}
+
+@test:Config {
+    groups: ["mock"]
+}
+isolated function testBinaryAttachmentPopulatesRawData() returns error? {
+    oas:MessagePartBody bodyPart = {attachmentId: "binary", size: 2, data: "__4="};
+    Attachment attachment = check convertOASMessagePartBodyToAttachment(bodyPart);
+    test:assertEquals(attachment.rawData, [<byte>0xFF, <byte>0xFE],
+            msg = "Binary attachment content should be stored in rawData");
+    test:assertTrue(attachment.data is (), msg = "data field should be nil for binary attachment");
+}
+
+@test:Config {
+    groups: ["mock"]
+}
+isolated function testBinaryMessagePartPopulatesRawData() returns error? {
+    oas:MessagePart part = {partId: "1", body: {data: "__4="}};
+    MessagePart messagePart = check convertOASMessagePartToMultipartMessageBody(part);
+    test:assertEquals(messagePart.rawData, [<byte>0xFF, <byte>0xFE],
+            msg = "Binary message part content should be stored in rawData");
+    test:assertTrue(messagePart.data is (), msg = "data field should be nil for binary message part");
+}
+
+@test:Config {
+    groups: ["mock"]
+}
 function testAttachmentSendFailure() returns error? {
     MessageRequest sendMsg = {
         attachments: [

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -150,8 +150,10 @@ public type MessagePart record {
     string partId;
     # When present, contains the ID of an external attachment that can be retrieved in a separate `messages.attachments.get` request. When not present, the entire content of the message part body is contained in the data field.
     string attachmentId?;
-    # The body data of a MIME message part. May be empty for MIME container types that have no message body or when the body data is sent as a separate attachment. An attachment ID is present if the body data is contained in a separate attachment.
-    string data?;
+    # The body data of a MIME message part decoded as a UTF-8 string. May be empty for MIME container types that have no message body or when the body data is sent as a separate attachment. An attachment ID is present if the body data is contained in a separate attachment.
+    string data?; // TODO: This will deprecated in version 5.0.0 
+    # The body data of a MIME message part as raw decoded bytes. May be empty for MIME container types that have no message body or when the body data is sent as a separate attachment. An attachment ID is present if the body data is contained in a separate attachment.
+    byte[] rawData?;
     # Number of bytes for the message part data.
     int:Signed32 size?;
     # The child MIME message parts of this part. This only applies to container MIME message parts, for example `multipart/*`. For non- container MIME message part types, such as `text/plain`, this field is empty. For more information, see RFC 1521.
@@ -193,8 +195,10 @@ public type ModifyMessageRequest record {|
 public type Attachment record {
     # Id of the attachment.
     string attachmentId?;
-    # The body data of a MIME message part. 
-    string data?;
+    # The attachment data decoded as a UTF-8 string. Populated only when the content is valid UTF-8 text.
+    string data?; // TODO: This will deprecated in version 5.0.0 
+    # The attachment data as raw decoded bytes. Populated for binary content that cannot be represented as a UTF-8 string (e.g. PDF, images).
+    byte[] rawData?;
     # Number of bytes for the message part data (encoding notwithstanding).
     int:Signed32 size?;
 };

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -20,10 +20,18 @@ isolated function base64UrlEncode(string contentToBeEncoded) returns string {
     return re `/`.replaceAll(re `\+`.replaceAll(base64EncodedString, DASH), UNDERSCORE);
 }
 
-isolated function base64UrlDecode(string contentToBeDecoded) returns string|error {
+isolated function base64UrlDecodeToBytes(string contentToBeDecoded) returns byte[]|error {
     do {
         string base64Encoded = re `_`.replaceAll(re `-`.replaceAll(contentToBeDecoded, PLUS), FORWARD_SLASH);
-        return check string:fromBytes(check array:fromBase64(base64Encoded));
+        return check array:fromBase64(base64Encoded);
+    } on fail error e {
+        return error ValueEncodeError(" is not a valid Base64 URL encoded value.", e);
+    }
+}
+
+isolated function base64UrlDecodeToString(string contentToBeDecoded) returns string|error {
+    do {
+        return check string:fromBytes(check base64UrlDecodeToBytes(contentToBeDecoded));
     } on fail error e {
         return error ValueEncodeError(" is not a valid Base64 URL encoded value.", e);
     }

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [4.2.0] - 2026-03-10
+
+### Added
+
+- Add `rawData` field (`byte[]`) to `Attachment` and `MessagePart` types to support binary content (e.g. PDF, images) that cannot be represented as UTF-8 strings
+
+### Fixed
+
+- Fix binary attachment retrieval failing with `"array contains invalid UTF-8 byte value"` error when decoding non-UTF-8 content from the Gmail API
+
 ## [4.0.1] - 2024-02-13
 
 ### Changed


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
