### PR TITLE
Fix invalid UTF-8 error when retrieving binary attachments (e.g. PDF)

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.2"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.8"
+version = "2.14.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.12.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -285,10 +285,11 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.7.0"
+version = "2.11.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"}
 ]
 
 [[package]]
@@ -308,7 +309,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/data_mappings.bal
+++ b/ballerina/data_mappings.bal
@@ -27,7 +27,7 @@ isolated function convertOASMessageToMessage(oas:Message response) returns Messa
     do {
         string? rawMessage = response.raw;
         if rawMessage is string {
-            email.raw = check base64UrlDecode(rawMessage);
+            email.raw = check base64UrlDecodeToString(rawMessage);
         }
     } on fail error err {
         return error ValueEncodeError(string `Returned message raw field${err.message()}`, err.cause());
@@ -106,7 +106,7 @@ returns MessagePart|error {
         do {
             string? data = body.data;
             if data is string {
-                messagePart.data = check base64UrlDecode(data);
+                messagePart.data = check base64UrlDecodeToBytes(data);
             }
         } on fail error err {
             check error ValueEncodeError(
@@ -270,7 +270,7 @@ isolated function convertOASMessagePartBodyToAttachment(oas:MessagePartBody body
     do {
         string? data = bodyPart.data;
         if data is string {
-            attachment.data = check base64UrlDecode(data);
+            attachment.data = check base64UrlDecodeToBytes(data);
         }
     } on fail error err {
         return error ValueEncodeError(

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -227,7 +227,7 @@ function testMessageUntrash() returns error? {
 }
 function testGetAttachment() returns error? {
     Attachment attachment = check gmailClient->/users/me/messages/[sentMessageId]/attachments/[attachmentId];
-    test:assertTrue(attachment.data != "", msg = "/users/[userId]/messages/[sentMessageId]/attachments/[attachmentId] failed");
+    test:assertTrue((attachment.data ?: []).length() > 0, msg = "/users/[userId]/messages/[sentMessageId]/attachments/[attachmentId] failed");
 }
 
 @test:Config {

--- a/ballerina/tests/test_w_mock_server.bal
+++ b/ballerina/tests/test_w_mock_server.bal
@@ -135,6 +135,41 @@ function testUrlDecodeFailure() returns error? {
 @test:Config {
     groups: ["mock"]
 }
+isolated function testBase64UrlDecodeWithInvalidInput() {
+    byte[]|error result = base64UrlDecodeToBytes("@#$%");
+    test:assertTrue(result is error,
+            msg = "base64UrlDecodeToBytes should return an error for invalid base64url input");
+    if result is error {
+        test:assertEquals(result.message(), " is not a valid Base64 URL encoded value.",
+                msg = "base64UrlDecodeToBytes error message mismatch");
+    }
+}
+
+@test:Config {
+    groups: ["mock"]
+}
+isolated function testBinaryAttachmentPopulatesData() returns error? {
+    // "__4=" is base64url for [0xFF, 0xFE] — non-UTF-8 binary bytes (e.g. PDF content).
+    oas:MessagePartBody bodyPart = {attachmentId: "binary", size: 2, data: "__4="};
+    Attachment attachment = check convertOASMessagePartBodyToAttachment(bodyPart);
+    test:assertEquals(attachment.data, [<byte>0xFF, <byte>0xFE],
+            msg = "Binary attachment content should be decoded into data as byte[]");
+}
+
+@test:Config {
+    groups: ["mock"]
+}
+isolated function testBinaryMessagePartPopulatesData() returns error? {
+    // "__4=" is base64url for [0xFF, 0xFE] — non-UTF-8 binary bytes (e.g. PDF content).
+    oas:MessagePart part = {partId: "1", body: {data: "__4="}};
+    MessagePart messagePart = check convertOASMessagePartToMultipartMessageBody(part);
+    test:assertEquals(messagePart.data, [<byte>0xFF, <byte>0xFE],
+            msg = "Binary message part content should be decoded into data as byte[]");
+}
+
+@test:Config {
+    groups: ["mock"]
+}
 function testAttachmentSendFailure() returns error? {
     MessageRequest sendMsg = {
         attachments: [
@@ -270,7 +305,7 @@ function testPostMessageMock() returns error? {
 }
 function testGetAttachmentMock() returns error? {
     Attachment attachment = check gmailClientForMockServer->/users/me/messages/["123"]/attachments/["123"];
-    test:assertTrue(attachment.data != "", msg = "/users/[userId]/messages/[sentMessageId]/attachments/[attachmentId] failed");
+    test:assertTrue((attachment.data ?: []).length() > 0, msg = "/users/[userId]/messages/[sentMessageId]/attachments/[attachmentId] failed");
 }
 
 @test:Config {

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -168,9 +168,9 @@ public type MessagePart record {
     MessagePartBody body?;
     # When present, contains the ID of an external attachment that can be retrieved in a separate `messages.attachments.get` request. When not present, the entire content of the message part body is contained in the data field
     string attachmentId?;
-    # The body data of a MIME message part. May be empty for MIME container types that have no message body or when the body data is sent as a separate attachment. An attachment ID is present if the body data is contained in a separate attachment
-    string data?;
-    # Number of bytes for the message part data
+    # The body data of a MIME message part as decoded bytes. May be empty for MIME container types that have no message body or when the body data is sent as a separate attachment. An attachment ID is present if the body data is contained in a separate attachment.
+    byte[] data?;
+    # Number of bytes for the message part data.
     int:Signed32 size?;
 };
 
@@ -543,8 +543,8 @@ public type GmailUsersMessagesAttachmentsGetQueries record {
 public type Attachment record {
     # Id of the attachment.
     string attachmentId?;
-    # The body data of a MIME message part. 
-    string data?;
+    # The attachment data as decoded bytes.
+    byte[] data?;
     # Number of bytes for the message part data (encoding notwithstanding).
     int:Signed32 size?;
 };

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -20,10 +20,18 @@ isolated function base64UrlEncode(string contentToBeEncoded) returns string {
     return re `/`.replaceAll(re `\+`.replaceAll(base64EncodedString, DASH), UNDERSCORE);
 }
 
-isolated function base64UrlDecode(string contentToBeDecoded) returns string|error {
+isolated function base64UrlDecodeToBytes(string contentToBeDecoded) returns byte[]|error {
     do {
         string base64Encoded = re `_`.replaceAll(re `-`.replaceAll(contentToBeDecoded, PLUS), FORWARD_SLASH);
-        return check string:fromBytes(check array:fromBase64(base64Encoded));
+        return check array:fromBase64(base64Encoded);
+    } on fail error e {
+        return error ValueEncodeError(" is not a valid Base64 URL encoded value.", e);
+    }
+}
+
+isolated function base64UrlDecodeToString(string contentToBeDecoded) returns string|error {
+    do {
+        return check string:fromBytes(check base64UrlDecodeToBytes(contentToBeDecoded));
     } on fail error e {
         return error ValueEncodeError(" is not a valid Base64 URL encoded value.", e);
     }

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Changed
+
+- Improve APIs to align with Ballerina standards
+
 ## [4.2.0] - 2026-03-10
 
 ### Added
@@ -20,10 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix binary attachment retrieval failing with `"array contains invalid UTF-8 byte value"` when attachment data is non-UTF-8 content
-
-### Changed
-
-- Improve APIs to align with Ballerina standards
 
 ## [4.0.1] - 2024-02-13
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improve APIs to align with ballerina standards
+## [4.2.0] - 2026-03-10
+
+### Added
+
+- Add `rawData` (`byte[]`) field to `Attachment` and `MessagePart` types to support binary content (e.g. PDFs, images) that cannot be represented as a UTF-8 string
+
+### Fixed
+
+- Fix binary attachment retrieval failing with `"array contains invalid UTF-8 byte value"` when attachment data is non-UTF-8 content
+
+### Changed
+
+- Improve APIs to align with Ballerina standards
 
 ## [4.0.1] - 2024-02-13
 


### PR DESCRIPTION
## Purpose

Fixes:

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes encoding errors when retrieving binary attachments (e.g. PDFs) by refactoring base64url decoding to correctly handle both text and binary content, updating types and tests, and bumping several dependencies.

## Key changes

- Types
  - MessagePart.data: string? → byte[]?
  - Attachment.data: string? → byte[]?

- Decoding logic
  - Added base64UrlDecodeToBytes(string) -> byte[]|error for binary decoding
  - Added base64UrlDecodeToString(string) -> string|error for text decoding
  - Replaced previous base64UrlDecode calls with the appropriate specialized functions:
    - Raw RFC‑822 email content decoded with base64UrlDecodeToString
    - Message parts and attachments decoded with base64UrlDecodeToBytes

- Tests
  - Added tests for invalid base64url input handling
  - Added tests verifying binary attachment and message part decoding to byte[] values
  - Adjusted existing assertions to safely handle nullable data fields

- Other
  - Updated changelog with a 4.2.0 entry describing binary data support and the fix
  - Updated dependency versions in Dependencies.toml (crypto, http, log, observe, time, task, and related packages)
  - Updated changelog file in a commit

## Outcome

Attachments and message parts containing non‑UTF‑8 binary data are now decoded to byte arrays, preventing encoding errors while preserving string decoding for raw message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->